### PR TITLE
Added support NAL unit overlapping between PES packets

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -247,6 +247,18 @@
   _parseAVCPES(pes) {
     var units,track = this._avcTrack,avcSample,key = false;
     units = this._parseAVCNALu(pes.data);
+    // no NALu found
+    if(units.length === 0 & this._avcSamples.length > 0) {
+      // append pes.data to previous NAL unit
+      var lastavcSample = this._avcSamples[this._avcSamples.length-1];
+      var lastUnit = lastavcSample.units.units[lastavcSample.units.units.length-1];
+      var tmp = new Uint8Array(lastUnit.data.byteLength+pes.data.byteLength);
+      tmp.set(lastUnit.data,0);
+      tmp.set(pes.data,lastUnit.data.byteLength);
+      lastUnit.data = tmp;
+      lastavcSample.units.length+=pes.data.byteLength;
+      this._avcSamplesLength+=pes.data.byteLength;
+    }
     //free pes.data to save up some memory
     pes.data = null;
     units.units.forEach(unit => {
@@ -292,10 +304,12 @@
     });
     //build sample from PES
     // Annex B to MP4 conversion to be done
-    avcSample = { units : units, pts : pes.pts, dts : pes.dts , key : key};
-    this._avcSamples.push(avcSample);
-    this._avcSamplesLength += units.length;
-    this._avcSamplesNbNalu += units.units.length;
+    if(units.length) {
+      avcSample = { units : units, pts : pes.pts, dts : pes.dts , key : key};
+      this._avcSamples.push(avcSample);
+      this._avcSamplesLength += units.length;
+      this._avcSamplesNbNalu += units.units.length;
+    }
   }
 
 


### PR DESCRIPTION
This should add support for  NAL units overlapping between PES packets, as discussed in https://github.com/dailymotion/hls.js/issues/6.

Note I haven't been able to test it locally yet as the I haven't been able to get the build to work on windows.