### PR TITLE
fix browserify Hls export name

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "find dist -mindepth 1 -delete",
     "prebuild": "npm run clean & npm run test",
-    "build": "browserify -s hls src/hls.js -o dist/hls.js",
+    "build": "browserify -s Hls src/hls.js -o dist/hls.js",
     "postbuild": "npm run minify",
     "minify": "uglifyjs dist/hls.js -c sequences=true,dead_code=true,conditionals=true,booleans=true,unused=true,if_return=true,join_vars=true,drop_console=true -m sort --screw-ie8 > dist/hls.min.js",
     "watch": "watchify --debug -s Hls src/hls.js -o dist/hls.js",


### PR DESCRIPTION
Browserify export name specified in package.json is 'hls', but expected 'Hls' (as specified for watchify, for example).  