### PR TITLE
XhrLoader: allow custom setup of XMLHttpRequest

### DIFF
--- a/API.md
+++ b/API.md
@@ -185,7 +185,8 @@ configuration parameters could be provided to hls.js upon instantiation of Hls O
       fpsDroppedMonitoringPeriod : 5000,
       fpsDroppedMonitoringThreshold : 0.2,
       appendErrorMaxRetry : 200,
-      loader : customLoader
+      loader : customLoader,
+      xhrSetup : XMLHttpRequestSetupCallback
     };
 
 
@@ -269,6 +270,22 @@ var customLoader = function() {
   /* destroy loading context */
   this.destroy = function() {}
   }
+```
+
+#### ```xhrSetup```
+(default : none)
+
+XmlHttpRequest customization callback for default loader.
+
+This could be function with single argument of type XMLHttpRequest.
+If specified, default loader will call this function before ```xhr.send()```, so that allow user to modify/setup xhr.
+
+```js
+var config = {
+  xhrSetup: function(xhr) {
+    xhr.withCredentials = true; // do send cookies
+  }
+}
 ```
 
 ## Video Binding/Unbinding API

--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -27,7 +27,7 @@ class FragmentLoader {
     this.frag = frag;
     this.frag.loaded = 0;
     var config = this.hls.config;
-    frag.loader = this.loader = new config.loader();
+    frag.loader = this.loader = new config.loader(config);
     this.loader.load(frag.url, 'arraybuffer', this.loadsuccess.bind(this), this.loaderror.bind(this), this.loadtimeout.bind(this), config.fragLoadingTimeOut, config.fragLoadingMaxRetry, config.fragLoadingRetryDelay, this.loadprogress.bind(this));
   }
 

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -40,7 +40,7 @@ class PlaylistLoader {
     this.url = url;
     this.id = id1;
     this.id2 = id2;
-    this.loader = new config.loader();
+    this.loader = new config.loader(config);
     this.loader.load(url, '', this.loadsuccess.bind(this), this.loaderror.bind(this), this.loadtimeout.bind(this), config.manifestLoadingTimeOut, config.manifestLoadingMaxRetry, config.manifestLoadingRetryDelay);
   }
 

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -6,7 +6,10 @@ import {logger} from '../utils/logger';
 
 class XhrLoader {
 
-  constructor() {
+  constructor(config) {
+    if (config && config.xhrSetup) {
+      this.xhrSetup = config.xhrSetup;
+    }
   }
 
   destroy() {
@@ -48,6 +51,9 @@ class XhrLoader {
     xhr.responseType = this.responseType;
     this.stats.tfirst = null;
     this.stats.loaded = 0;
+    if (this.xhrSetup) {
+      this.xhrSetup(xhr);
+    }
     xhr.send();
   }
 


### PR DESCRIPTION
Added config option 'xhrSetup'. This could be function with single argument of type XMLHttpRequest.
If specified, XhrLoader will call this function before xhr.send(), so that allow user to modify/setup xhr.

There are cases we need just simple XHR tuning. For example, set withCredentials=true to send cookies. IMHO, in such cases it is convenient to implement simple function instead of full featured loader.