### PR TITLE
Fire Events.FRAG_PARSING_METADATA with id3 samples

### DIFF
--- a/API.md
+++ b/API.md
@@ -464,6 +464,8 @@ full list of Events available below :
     -  data: { frag : fragment object, payload : fragment payload, stats : { trequest, tfirst, tload, length}}
   - `Hls.Events.FRAG_PARSING_INIT_SEGMENT` - fired when Init Segment has been extracted from fragment
     -  data: { moov : moov MP4 box, codecs : codecs found while parsing fragment}    
+  - `Hls.Events.FRAG_PARSING_METADATA`  - fired when parsing id3 is completed
+      -  data: { samples : [ id3 pes - pts and dts timestamp are relative, values are in seconds]}
   - `Hls.Events.FRAG_PARSING_DATA`  - fired when moof/mdat have been extracted from fragment
     -  data: { moof : moof MP4 box, mdat : mdat MP4 box, startPTS : PTS of first sample, endPTS : PTS of last sample, startDTS : DTS of first sample, endDTS : DTS of last sample, type : stream type (audio or video), nb : number of samples}
   - `Hls.Events.FRAG_PARSED`  - fired when fragment parsing is completed

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ as of today, it is supported on:
     - retry mechanism embedded in the library
     - recovery actions could be triggered fix fatal media or network errors
   - [Redundant/Failover Playlists](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/UsingHTTPLiveStreaming/UsingHTTPLiveStreaming.html#//apple_ref/doc/uid/TP40008332-CH102-SW22)
+  - Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS)
 
 ## Not Supported (Yet)
 
   - AAC / MP3 / WebVTT container
   - AES-128 decryption
   - Alternate Audio Track Rendition (Master Playlist with alternative Audio)  
-  - Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS)
 
 ### Supported M3U8 tags
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -258,6 +258,9 @@ $(document).ready(function() {
           var event = {time : Date.now() - events.t0, type : "init segment"};
           events.video.push(event);
        });
+       hls.on(Hls.Events.FRAG_PARSING_METADATA, function(event, data) {
+         console.log("Id3 samples ", data.samples);
+       });
        hls.on(Hls.Events.LEVEL_SWITCH,function(event,data) {
           events.level.push({time : Date.now() - events.t0, id : data.level, bitrate : Math.round(hls.levels[data.level].bitrate/1000)});
           updateLevelInfo();

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -76,6 +76,11 @@ class Demuxer {
           nb: ev.data.nb
         });
         break;
+        case Event.FRAG_PARSING_METADATA:
+        this.hls.trigger(Event.FRAG_PARSING_METADATA, {
+          samples: ev.data.samples
+        });
+        break;
       default:
         this.hls.trigger(ev.data.event, ev.data.data);
         break;

--- a/src/demux/tsdemuxerworker.js
+++ b/src/demux/tsdemuxerworker.js
@@ -62,6 +62,11 @@ var TSDemuxerWorker = function (self) {
   observer.on(Event.ERROR, function(event, data) {
     self.postMessage({event: event, data: data});
   });
+
+  observer.on(Event.FRAG_PARSING_METADATA, function(event, data) {
+    var objData = {event: event, samples: data.samples};
+    self.postMessage(objData);
+  });
 };
 
 export default TSDemuxerWorker;

--- a/src/events.js
+++ b/src/events.js
@@ -25,7 +25,7 @@ export default {
   FRAG_LOADED: 'hlsFragLoaded',
   // fired when Init Segment has been extracted from fragment - data: { moov : moov MP4 box, codecs : codecs found while parsing fragment}
   FRAG_PARSING_INIT_SEGMENT: 'hlsFragParsingInitSegment',
-  // fired when paring id3 is completed - data: { samples : [ id3 samples pes ] }
+  // fired when parsing id3 is completed - data: { samples : [ id3 samples pes ] }
   FRAG_PARSING_METADATA: 'hlsFraParsingMetadata',
   // fired when moof/mdat have been extracted from fragment - data: { moof : moof MP4 box, mdat : mdat MP4 box}
   FRAG_PARSING_DATA: 'hlsFragParsingData',

--- a/src/events.js
+++ b/src/events.js
@@ -25,6 +25,8 @@ export default {
   FRAG_LOADED: 'hlsFragLoaded',
   // fired when Init Segment has been extracted from fragment - data: { moov : moov MP4 box, codecs : codecs found while parsing fragment}
   FRAG_PARSING_INIT_SEGMENT: 'hlsFragParsingInitSegment',
+  // fired when paring id3 is completed - data: { samples : [ id3 samples pes ] }
+  FRAG_PARSING_METADATA: 'hlsFraParsingMetadata',
   // fired when moof/mdat have been extracted from fragment - data: { moof : moof MP4 box, mdat : mdat MP4 box}
   FRAG_PARSING_DATA: 'hlsFragParsingData',
   // fired when fragment parsing is completed - data: undefined

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -356,8 +356,21 @@ class MP4Remuxer {
 
   remuxID3(track,timeOffset) {
     // consume samples
+    if(track.samples.length) {
+      var length = track.samples.length, sample;
+      for(var index = 0; index < length; index++) {
+        sample = track.samples[index];
+        // setting id3 pts, dts to relative time
+        // using this._initPTS and this._initDTS to calculate relative time
+        sample.pts = ((sample.pts - this._initPTS) / this.PES_TIMESCALE);
+        sample.dts = ((sample.dts - this._initDTS) / this.PES_TIMESCALE);
+      }
+      this.observer.trigger(Event.FRAG_PARSING_METADATA, {
+        samples:track.samples.slice(0)
+      });
+    }
+
     track.samples = [];
-    //please lint
     timeOffset = timeOffset;
   }
 
@@ -385,4 +398,3 @@ class MP4Remuxer {
 }
 
 export default MP4Remuxer;
-

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -366,7 +366,7 @@ class MP4Remuxer {
         sample.dts = ((sample.dts - this._initDTS) / this.PES_TIMESCALE);
       }
       this.observer.trigger(Event.FRAG_PARSING_METADATA, {
-        samples:track.samples.slice(0)
+        samples:track.samples
       });
     }
 


### PR DESCRIPTION
Fires Events.FRAG_PARSING_METADATA on parsing id3 tags. Event data.samples array contains ID3 PES instances. sample.pts and sample.dts are converted to relative time, values are in seconds.  FIxes #20 