### PR TITLE
Fixes for detaching / re-attaching video (for ads support for example)

### DIFF
--- a/API.md
+++ b/API.md
@@ -450,7 +450,7 @@ hls.on(Hls.Events.LEVEL_LOADED,function(event,data) {
 full list of Events available below :
 
   - `Hls.Events.MSE_ATTACHED`  - fired when MediaSource has been succesfully attached to video element.
-    -  data: { mediaSource }
+    -  data: { video , mediaSource }
   - `Hls.Events.MSE_DETACHED`  - fired when MediaSource has been detached from video element.
     -  data: { }
   - `Hls.Events.MANIFEST_LOADING`  - fired to signal that a manifest loading starts

--- a/API.md
+++ b/API.md
@@ -487,6 +487,8 @@ full list of Events available below :
     -  data: {curentDropped : nb of dropped frames in last monitoring period, currentDecoded: nb of decoded frames in last monitoring period, totalDropped : total dropped frames on this video element}
   - `Hls.Events.ERROR` -  Identifier for an error event
     - data: { type : error Type, details : error details, fatal : is error fatal or not, other error specific data} 
+  - `Hls.Events.DESTROYING` -  fired when hls.js instance starts destroying. Different from MSE_DETACHED as one could want to detach and reattach a video to the instance of hls.js to handle mid-rolls for example.
+    - data: { }
 
 
 ##Errors

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -45,14 +45,6 @@ class BufferController {
   destroy() {
     this.stop();
     this.hls.off(Event.MANIFEST_PARSED, this.onmp);
-    // remove video listener
-    if (this.video) {
-      this.video.removeEventListener('seeking', this.onvseeking);
-      this.video.removeEventListener('seeked', this.onvseeked);
-      this.video.removeEventListener('loadedmetadata', this.onvmetadata);
-      this.video.removeEventListener('ended', this.onvended);
-      this.onvseeking = this.onvseeked = this.onvmetadata = null;
-    }
     this.state = this.IDLE;
   }
 
@@ -710,6 +702,14 @@ class BufferController {
   }
 
   onMSEDetached() {
+    // remove video listeners
+    if (this.video) {
+      this.video.removeEventListener('seeking', this.onvseeking);
+      this.video.removeEventListener('seeked', this.onvseeked);
+      this.video.removeEventListener('loadedmetadata', this.onvmetadata);
+      this.video.removeEventListener('ended', this.onvended);
+      this.onvseeking = this.onvseeked = this.onvmetadata = null;
+    }
     this.video = null;
     this.loadedmetadata = false;
     this.stop();

--- a/src/events.js
+++ b/src/events.js
@@ -38,5 +38,7 @@ export default {
     // Identifier for a FPS drop event - data: {curentDropped, currentDecoded, totalDroppedFrames}
   FPS_DROP: 'hlsFPSDrop',
   // Identifier for an error event - data: { type : error type, details : error details, fatal : if true, hls.js cannot/will not try to recover, if false, hls.js will try to recover,other error specific data}
-  ERROR: 'hlsError'
+  ERROR: 'hlsError',
+  // fired when hls.js instance starts destroying. Different from MSE_DETACHED as one could want to detach and reattach a video to the instance of hls.js to handle mid-rolls for example
+  DESTROYING: 'hlsDestroying',
 };

--- a/src/events.js
+++ b/src/events.js
@@ -1,5 +1,5 @@
 export default {
-  // fired when MediaSource has been succesfully attached to video element - data: { mediaSource }
+  // fired when MediaSource has been succesfully attached to video element - data: { video, mediaSource }
   MSE_ATTACHED: 'hlsMediaSourceAttached',
   // fired when MediaSource has been detached from video element - data: { }
   MSE_DETACHED: 'hlsMediaSourceDetached',

--- a/src/hls.js
+++ b/src/hls.js
@@ -127,7 +127,7 @@ class Hls {
     this.statsHandler.detachVideo(video);
     var ms = this.mediaSource;
     if (ms) {
-      if (ms.readyState !== 'ended') {
+      if (ms.readyState === 'open') {
         ms.endOfStream();
       }
       ms.removeEventListener('sourceopen', this.onmso);

--- a/src/hls.js
+++ b/src/hls.js
@@ -91,6 +91,7 @@ class Hls {
 
   destroy() {
     logger.log('destroy');
+    this.trigger(Event.DESTROYING);
     this.playlistLoader.destroy();
     this.fragmentLoader.destroy();
     this.levelController.destroy();


### PR DESCRIPTION
- A couple of fixes on detachVideo / destroy
- Added a DESTROYING event, as MSE_DETACHED isn't equivalent in that use case