### PR TITLE
Add two new events triggered when level details and PTS information have been updated

### DIFF
--- a/API.md
+++ b/API.md
@@ -465,6 +465,10 @@ full list of Events available below :
     -  data: { url : level URL, level : id of level being loaded}
   - `Hls.Events.LEVEL_LOADED`  - fired when a level playlist loading finishes
     -  data: { details : levelDetails object, levelId : id of loaded level, stats : { trequest, tfirst, tload, mtime} }
+  - `Hls.Events.LEVEL_UPDATED`  - fired when a level's details have been updated based on previous details, after it has been loaded
+    -  data: { details : levelDetails object, level : id of updated level }
+  - `Hls.Events.LEVEL_PTS_UPDATED`  - fired when a level's PTS information has been updated after parsing a fragment
+    -  data: { details : levelDetails object, level : id of updated level, drift: PTS drift observed when parsing last fragment } 
   - `Hls.Events.LEVEL_SWITCH`  - fired when a level switch is requested
     -  data: { levelId : id of new level }
   - `Hls.Events.FRAG_LOADING`  - fired when a fragment loading starts

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -837,6 +837,7 @@ class BufferController {
     }
     // override level info
     curLevel.details = newDetails;
+    this.hls.trigger(Event.LEVEL_UPDATED, { details: newDetails, level: newLevelId });
 
     // compute start position
     if (this.startLevelLoaded === false) {
@@ -932,7 +933,9 @@ class BufferController {
       var level = this.levels[this.level],
           frag = this.fragCurrent;
       logger.log(`parsed data, type/startPTS/endPTS/startDTS/endDTS/nb:${data.type}/${data.startPTS.toFixed(3)}/${data.endPTS.toFixed(3)}/${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}/${data.nb}`);
-      LevelHelper.updateFragPTS(level.details,frag.sn,data.startPTS,data.endPTS);
+      var drift = LevelHelper.updateFragPTS(level.details,frag.sn,data.startPTS,data.endPTS);
+      this.hls.trigger(Event.LEVEL_PTS_UPDATED, {details: level.details, level: this.level, drift: drift});
+      
       this.mp4segments.push({type: data.type, data: data.moof});
       this.mp4segments.push({type: data.type, data: data.mdat});
       this.nextLoadPosition = data.endPTS;

--- a/src/events.js
+++ b/src/events.js
@@ -15,6 +15,10 @@ export default {
   LEVEL_LOADING: 'hlsLevelLoading',
   // fired when a level playlist loading finishes - data: { details : levelDetails object, level : id of loaded level, stats : { trequest, tfirst, tload, mtime} }
   LEVEL_LOADED: 'hlsLevelLoaded',
+  // fired when a level's details have been updated based on previous details, after it has been loaded. - data: { details : levelDetails object, level : id of updated level }
+  LEVEL_UPDATED: 'hlsLevelUpdated',
+  // fired when a level's PTS information has been updated after parsing a fragment - data: { details : levelDetails object, level : id of updated level, drift: PTS drift observed when parsing last fragment } 
+  LEVEL_PTS_UPDATED: 'hlsPTSUpdated',
   // fired when a level switch is requested - data: { level : id of new level }
   LEVEL_SWITCH: 'hlsLevelSwitch',
   // fired when a fragment loading starts - data: { frag : fragment object}

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -60,7 +60,7 @@ class LevelHelper {
     var fragIdx, fragments, frag, i;
     // exit if sn out of range
     if (sn < details.startSN || sn > details.endSN) {
-      return;
+      return 0;
     }
     fragIdx = sn - details.startSN;
     fragments = details.fragments;

--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -69,6 +69,9 @@ class LevelHelper {
       startPTS = Math.max(startPTS,frag.startPTS);
       endPTS = Math.min(endPTS, frag.endPTS);
     }
+      
+    var drift = startPTS - frag.start;
+      
     frag.start = frag.startPTS = startPTS;
     frag.endPTS = endPTS;
     frag.duration = endPTS - startPTS;
@@ -83,6 +86,8 @@ class LevelHelper {
     }
     details.PTSKnown = true;
     //logger.log(`                                            frag start/end:${startPTS.toFixed(3)}/${endPTS.toFixed(3)}`);
+      
+    return drift;
   }
 
   static updatePTS(fragments,fromIdx, toIdx) {


### PR DESCRIPTION
The goal behind these changes is to allow code external to the player to be notified when level details and PTS information have been updated, so they can use the correct fragment timestamps.

I still have one interrogation: should we trigger LEVEL_PTS_UPDATED when drift = 0 ?