### PR TITLE
Added missing 'loader' property check

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -770,7 +770,9 @@ class BufferController {
         logger.log('seeking outside of buffer while fragment load in progress, cancel fragment load');
         var fragCurrent = this.fragCurrent;
         if (fragCurrent) {
-          fragCurrent.loader.abort();
+          if (fragCurrent.loader) {
+            fragCurrent.loader.abort();
+          }
           this.fragCurrent = null;
         }
         this.fragPrevious = null;


### PR DESCRIPTION
I'm not sure why the `loader` property doesn't exist, but in other places in the file where `abort()` is called you do this check first.