### PR TITLE
Slightly improved logging module

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -15,15 +15,25 @@ let lastCallTime;
 
 function noop() {}
 
+function formatMsgWithTimeInfo(msg) {
+  const now = Date.now();
+  const diff = lastCallTime ? '+' + (now - lastCallTime) : '0';
+  lastCallTime = now;
+  msg = (new Date(now)).toISOString() + ' | [' +  type + '] > ' + msg + ' ( ' + diff + ' ms )';
+  return msg;
+}
+
+function formatMsg(msg) {
+  msg = '[' +  type + '] > ' + msg + ' ( ' + diff + ' ms )';
+  return msg;
+}
+
 function consolePrintFn(type) {
-  var func = window.console[type];
+  const func = window.console[type];
   if (func) {
     return function(...args) {
       if(args[0]) {
-        const now = Date.now();
-        const diff = lastCallTime ? '+' + (now - lastCallTime) : '0';
-        args[0] = (new Date(now)).toISOString() + ' | [' +  type + '] > ' + args[0] + ' ( ' + diff + ' ms )';
-        lastCallTime = now;
+        args[0] = formatMsg(args[0]);
       }
       func.apply(window.console, args);
     };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -11,6 +11,8 @@ const fakeLogger = {
 
 let exportedLogger = fakeLogger;
 
+let lastCallTime;
+
 function noop() {}
 
 function consolePrintFn(type) {
@@ -18,7 +20,10 @@ function consolePrintFn(type) {
   if (func) {
     return function(...args) {
       if(args[0]) {
-        args[0] = (new Date()).toISOString() + ' | [' +  type + '] > ' + args[0];
+        const now = Date.now();
+        const diff = lastCallTime ? '+' + (now - lastCallTime) : '0';
+        args[0] = (new Date(now)).toISOString() + ' | [' +  type + '] > ' + args[0] + ' ( ' + diff + ' ms )';
+        lastCallTime = now;
       }
       func.apply(window.console, args);
     };
@@ -36,8 +41,8 @@ export var enableLogs = function(debugConfig) {
   if (debugConfig === true || typeof debugConfig === 'object') {
     exportLoggerFunctions(debugConfig,
       // Remove out from list here to hard-disable a log-level
-      'trace',
-      //'debug',
+      //'trace',
+      'debug',
       'log',
       'info',
       'warn',

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -15,7 +15,7 @@ let lastCallTime;
 
 function noop() {}
 
-function formatMsgWithTimeInfo(msg) {
+function formatMsgWithTimeInfo(type, msg) {
   const now = Date.now();
   const diff = lastCallTime ? '+' + (now - lastCallTime) : '0';
   lastCallTime = now;
@@ -23,8 +23,8 @@ function formatMsgWithTimeInfo(msg) {
   return msg;
 }
 
-function formatMsg(msg) {
-  msg = '[' +  type + '] > ' + msg + ' ( ' + diff + ' ms )';
+function formatMsg(type, msg) {
+  msg = '[' +  type + '] > ' + msg;
   return msg;
 }
 
@@ -33,7 +33,7 @@ function consolePrintFn(type) {
   if (func) {
     return function(...args) {
       if(args[0]) {
-        args[0] = formatMsg(args[0]);
+        args[0] = formatMsg(type, args[0]);
       }
       func.apply(window.console, args);
     };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function noop() {}
-
-let fakeLogger = {
+const fakeLogger = {
+  trace: noop,
+  debug: noop,
   log: noop,
   warn: noop,
   info: noop,
@@ -11,22 +11,44 @@ let fakeLogger = {
 
 let exportedLogger = fakeLogger;
 
-export var enableLogs = function(debug) {
-  if (debug === true || typeof debug === 'object') {
-    exportedLogger.log = debug.log ? debug.log.bind(debug) : console.log.bind(console);
-    exportedLogger.info = debug.info ? debug.info.bind(debug) : console.info.bind(console);
-    exportedLogger.error = debug.error ? debug.error.bind(debug) : console.error.bind(console);
-    exportedLogger.warn = debug.warn ? debug.warn.bind(debug) : console.warn.bind(console);
+function noop() {}
+
+function consolePrintFn(type) {
+  var func = window.console[type];
+  if (func) {
+    return function(...args) {
+      if(args[0]) {
+        args[0] = (new Date()).toISOString() + ' | [' +  type + '] > ' + args[0];
+      }
+      func.apply(window.console, args);
+    };
+  }
+  return noop;
+}
+
+function exportLoggerFunctions(debugConfig, ...functions) {
+  functions.forEach(function(type) {
+    exportedLogger[type] = debugConfig[type] ? debugConfig[type].bind(debugConfig) : consolePrintFn(type);
+  });
+}
+
+export var enableLogs = function(debugConfig) {
+  if (debugConfig === true || typeof debugConfig === 'object') {
+    exportLoggerFunctions(debugConfig,
+      // Remove out from list here to hard-disable a log-level
+      'trace',
+      //'debug',
+      'log',
+      'info',
+      'warn',
+      'error'
+    );
     // Some browsers don't allow to use bind on console object anyway
     // fallback to default if needed
     try {
      exportedLogger.log();
-    }
-    catch (e) {
-      exportedLogger.log = noop;
-      exportedLogger.info = noop;
-      exportedLogger.error = noop;
-      exportedLogger.warn = noop;
+    } catch (e) {
+      exportedLogger = fakeLogger;
     }
   }
   else {


### PR DESCRIPTION
- Adds UTC date and log level to output
- Enables to easily wrap the input to format the output
- Adds support for `debug` and `trace`, when available via console
- Allows to easily hard-disable a level 
- Removes redundancy in code

Example:

```
2015-11-22T14:58:42.255Z | [log] > level 3 loaded [0,63],duration:634.584
logger.js:23 2015-11-22T14:58:42.256Z | [log] > Loading 0 of [0 ,63],level 3, currentTime:0,bufferEnd:0.000
logger.js:23 2015-11-22T14:58:44.199Z | [log] > Demuxing 0 of [0 ,63],level 3
logger.js:23 2015-11-22T14:58:44.233Z | [log] > selected A/V codecs for sourceBuffers:mp4a.40.5,avc1.64001f
logger.js:23 2015-11-22T14:58:44.242Z | [log] > parsed data, type/startPTS/endPTS/startDTS/endDTS/nb:video/0.033/10.033/0.000/10.000/600
logger.js:23 2015-11-22T14:58:44.245Z | [log] > parsed data, type/startPTS/endPTS/startDTS/endDTS/nb:audio/0.010/10.018/0.010/10.018/431
```
