### PR TITLE
Use performance timers for stats

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,6 +23,7 @@
   "white"     : true,
   "globals"   : {
     "console"     : true,
-    "MediaSource" : true
+    "MediaSource" : true,
+    "performance" : true
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -240,7 +240,7 @@ $(document).ready(function() {
       }
 
       $("#HlsStatus").text('loading ' + url);
-       events = { url : url, t0 : Date.now(), load : [], buffer : [], video : [], level : [], bitrate : []};
+       events = { url : url, t0 : performance.now(), load : [], buffer : [], video : [], level : [], bitrate : []};
        hls = new Hls({debug:true});
        $("#HlsStatus").text('loading manifest and attaching video element...');
        hls.loadSource(url);
@@ -248,23 +248,23 @@ $(document).ready(function() {
        hls.on(Hls.Events.MEDIA_ATTACHED,function() {
         $("#HlsStatus").text('MediaSource attached...');
           bufferingIdx = -1;
-          events.video.push({time : Date.now() - events.t0, type : "Media attached"});
+          events.video.push({time : performance.now() - events.t0, type : "Media attached"});
        });
        hls.on(Hls.Events.MEDIA_DETACHED,function() {
         $("#HlsStatus").text('MediaSource detached...');
           bufferingIdx = -1;
-          events.video.push({time : Date.now() - events.t0, type : "Media detached"});
+          events.video.push({time : performance.now() - events.t0, type : "Media detached"});
        });
        hls.on(Hls.Events.FRAG_PARSING_INIT_SEGMENT,function(event,data) {
           showCanvas();
-          var event = {time : Date.now() - events.t0, type : "init segment"};
+          var event = {time : performance.now() - events.t0, type : "init segment"};
           events.video.push(event);
        });
        hls.on(Hls.Events.FRAG_PARSING_METADATA, function(event, data) {
          console.log("Id3 samples ", data.samples);
        });
        hls.on(Hls.Events.LEVEL_SWITCH,function(event,data) {
-          events.level.push({time : Date.now() - events.t0, id : data.level, bitrate : Math.round(hls.levels[data.level].bitrate/1000)});
+          events.level.push({time : performance.now() - events.t0, id : data.level, bitrate : Math.round(hls.levels[data.level].bitrate/1000)});
           updateLevelInfo();
        });
        hls.on(Hls.Events.MANIFEST_PARSED,function(event,data) {
@@ -317,7 +317,7 @@ $(document).ready(function() {
             size : data.stats.length
           };
           events.load.push(event);
-          events.bitrate.push({time : Date.now() - events.t0, bitrate : event.bw , duration : data.frag.duration, level : event.id});
+          events.bitrate.push({time : performance.now() - events.t0, bitrate : event.bw , duration : data.frag.duration, level : event.id});
           if(hls.bufferTimer === undefined) {
             events.buffer.push({ time : 0, buffer : 0, pos: 0});
             hls.bufferTimer = window.setInterval(checkBuffer, 100);
@@ -360,7 +360,7 @@ $(document).ready(function() {
           stats.autoLevelCappingLast = hls.autoLevelCapping;
        });
        hls.on(Hls.Events.FRAG_CHANGED,function(event,data) {
-        var event = {time : Date.now() - events.t0, type : 'frag changed', name : data.frag.sn + ' @ ' + data.frag.level };
+        var event = {time : performance.now() - events.t0, type : 'frag changed', name : data.frag.sn + ' @ ' + data.frag.level };
         events.video.push(event);
         refreshCanvas();
         updateLevelInfo();
@@ -486,7 +486,7 @@ $(document).ready(function() {
        });
 
        hls.on(Hls.Events.FPS_DROP,function(event,data) {
-          var evt = {time : Date.now() - events.t0, type : "frame drop", name : data.currentDropped + "/" + data.currentDecoded};
+          var evt = {time : performance.now() - events.t0, type : "frame drop", name : data.currentDropped + "/" + data.currentDecoded};
           events.video.push(evt);
           if (stats) {
            if (stats.fpsDropEvent === undefined) {
@@ -580,7 +580,7 @@ var lastSeekingIdx, lastStartPosition,lastDuration;
       default:
       break;
     }
-    var event = {time : Date.now() - events.t0, type : evt.type, name : data};
+    var event = {time : performance.now() - events.t0, type : evt.type, name : data};
     events.video.push(event);
     if(evt.type === 'seeking') {
       lastSeekingIdx = events.video.length-1;
@@ -630,11 +630,11 @@ function timeRangesToString(r) {
         } else {
          // we are not at the end of the playlist ... real buffering
           if(bufferingIdx !== -1) {
-            bufferingDuration = Date.now() - events.t0 - events.video[bufferingIdx].time;
+            bufferingDuration = performance.now() - events.t0 - events.video[bufferingIdx].time;
             events.video[bufferingIdx].duration = bufferingDuration;
             events.video[bufferingIdx].name = bufferingDuration;
           } else {
-            events.video.push({ type : 'buffering' , time : Date.now() - events.t0 });
+            events.video.push({ type : 'buffering' , time : performance.now() - events.t0 });
             // we are in buffering state
             bufferingIdx = events.video.length-1;
           }
@@ -642,7 +642,7 @@ function timeRangesToString(r) {
       }
 
       if(bufferLen > 0.1 && bufferingIdx !=-1) {
-          bufferingDuration = Date.now() - events.t0 - events.video[bufferingIdx].time;
+          bufferingDuration = performance.now() - events.t0 - events.video[bufferingIdx].time;
           events.video[bufferingIdx].duration = bufferingDuration;
           events.video[bufferingIdx].name = bufferingDuration;
         // we are out of buffering state
@@ -650,7 +650,7 @@ function timeRangesToString(r) {
       }
 
       // update buffer/position for current Time
-      var event = { time : Date.now() - events.t0, buffer : Math.round(bufferLen*1000), pos: Math.round(pos*1000)};
+      var event = { time : performance.now() - events.t0, buffer : Math.round(bufferLen*1000), pos: Math.round(pos*1000)};
       var bufEvents = events.buffer, bufEventLen = bufEvents.length;
       if(bufEventLen > 1) {
         var event0 = bufEvents[bufEventLen-2],event1 = bufEvents[bufEventLen-1];

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -22,10 +22,10 @@ class AbrController {
   onFragmentLoadProgress(event, data) {
     var stats = data.stats;
     if (stats.aborted === undefined) {
-      this.lastfetchduration = (new Date() - stats.trequest) / 1000;
+      this.lastfetchduration = (performance.now() - stats.trequest) / 1000;
       this.lastfetchlevel = data.frag.level;
       this.lastbw = (stats.loaded * 8) / this.lastfetchduration;
-      //console.log('fetchDuration:${this.lastfetchduration},bw:${(this.lastbw/1000).toFixed(0)}/${stats.aborted}');
+      //console.log(`fetchDuration:${this.lastfetchduration},bw:${(this.lastbw/1000).toFixed(0)}/${stats.aborted}`);
     }
   }
 

--- a/src/controller/mse-media-controller.js
+++ b/src/controller/mse-media-controller.js
@@ -260,7 +260,7 @@ class MSEMediaController {
           frag.autoLevel = hls.autoLevelEnabled;
           if (this.levels.length > 1) {
             frag.expectedLen = Math.round(frag.duration * this.levels[level].bitrate / 8);
-            frag.trequest = new Date();
+            frag.trequest = performance.now();
           }
           // ensure that we are not reloading the same fragments in loop ...
           if (this.fragLoadIdx !== undefined) {
@@ -303,7 +303,7 @@ class MSEMediaController {
         /* only monitor frag retrieval time if
         (video not paused OR first fragment being loaded) AND autoswitching enabled AND not lowest level AND multiple levels */
         if (v && (!v.paused || this.loadedmetadata === false) && frag.autoLevel && this.level && this.levels.length > 1) {
-          var requestDelay = new Date() - frag.trequest;
+          var requestDelay = performance.now() - frag.trequest;
           // monitor fragment load progress after half of expected fragment duration,to stabilize bitrate
           if (requestDelay > (500 * frag.duration)) {
             var loadRate = frag.loaded * 1000 / requestDelay; // byte/s
@@ -906,7 +906,7 @@ class MSEMediaController {
         // switch back to IDLE state ... we just loaded a fragment to determine adequate start bitrate and initialize autoswitch algo
         this.state = State.IDLE;
         this.fragBitrateTest = false;
-        data.stats.tparsed = data.stats.tbuffered = new Date();
+        data.stats.tparsed = data.stats.tbuffered = performance.now();
         this.hls.trigger(Event.FRAG_BUFFERED, {stats: data.stats, frag: fragCurrent});
       } else {
         this.state = State.PARSING;
@@ -997,7 +997,7 @@ class MSEMediaController {
   onFragParsed() {
     if (this.state === State.PARSING) {
       this.state = State.PARSED;
-      this.stats.tparsed = new Date();
+      this.stats.tparsed = performance.now();
       //trigger handler right now
       this.tick();
     }
@@ -1026,7 +1026,7 @@ class MSEMediaController {
       var frag = this.fragCurrent, stats = this.stats;
       if (frag) {
         this.fragPrevious = frag;
-        stats.tbuffered = new Date();
+        stats.tbuffered = performance.now();
         this.fragLastKbps = Math.round(8 * stats.length / (stats.tbuffered - stats.tfirst));
         this.hls.trigger(Event.FRAG_BUFFERED, {stats: stats, frag: frag});
         logger.log(`media buffered : ${this.timeRangesToString(this.media.buffered)}`);

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -171,7 +171,7 @@ class PlaylistLoader {
       // fallback to initial URL
       url = this.url;
     }
-    stats.tload = new Date();
+    stats.tload = performance.now();
     stats.mtime = new Date(event.currentTarget.getResponseHeader('Last-Modified'));
     if (string.indexOf('#EXTM3U') === 0) {
       if (string.indexOf('#EXTINF:') > 0) {
@@ -182,7 +182,7 @@ class PlaylistLoader {
           hls.trigger(Event.MANIFEST_LOADED, {levels: [{url: url}], url: url, stats: stats});
         } else {
           var levelDetails = this.parseLevelPlaylist(string, url, id);
-          stats.tparsed = new Date();
+          stats.tparsed = performance.now();
           hls.trigger(Event.LEVEL_LOADED, {details: levelDetails, level: id, id: id2, stats: stats});
         }
       } else {

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -37,7 +37,7 @@ class XhrLoader {
     this.onProgress = onProgress;
     this.onTimeout = onTimeout;
     this.onError = onError;
-    this.stats = {trequest: new Date(), retry: 0};
+    this.stats = {trequest: performance.now(), retry: 0};
     this.timeout = timeout;
     this.maxRetry = maxRetry;
     this.retryDelay = retryDelay;
@@ -65,7 +65,7 @@ class XhrLoader {
 
   loadsuccess(event) {
     window.clearTimeout(this.timeoutHandle);
-    this.stats.tload = new Date();
+    this.stats.tload = performance.now();
     this.onSuccess(event, this.stats);
   }
 
@@ -92,7 +92,7 @@ class XhrLoader {
   loadprogress(event) {
     var stats = this.stats;
     if (stats.tfirst === null) {
-      stats.tfirst = new Date();
+      stats.tfirst = performance.now();
     }
     stats.loaded = event.loaded;
     if (this.onProgress) {


### PR DESCRIPTION
This makes the measurements more precise & monotonic, eg. avoiding issues when the local system time is adjusted.

Note that the measurements will have an arbitrary base and can't be compared using a regular Date.now(). This is new behavior but doesn't change any of the internal calculations that all rely on deltas.