### PR TITLE
Trigger event DESTROYING before detaching media in destroy()

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -94,8 +94,8 @@ class Hls {
 
   destroy() {
     logger.log('destroy');
-    this.detachMedia();
     this.trigger(Event.DESTROYING);
+    this.detachMedia();
     this.playlistLoader.destroy();
     this.fragmentLoader.destroy();
     this.levelController.destroy();


### PR DESCRIPTION
In my opinion, triggering DESTROYING should be the first step when destroying the instance of hls.js, even before we call detachMedia. It seems more intuitive to me, I think it's what developers would expect.