### PR TITLE
Fix index error in mse media controller when loading mid-fragment for live playlist

### DIFF
--- a/src/controller/mse-media-controller.js
+++ b/src/controller/mse-media-controller.js
@@ -229,7 +229,7 @@ class MSEMediaController {
                 /* we have no idea about which fragment should be loaded.
                    so let's load mid fragment. it will help computing playlist sliding and find the right one
                 */
-                frag = fragments[Math.round(fragLen / 2)];
+                frag = fragments[Math.min(fragLen - 1, Math.round(fragLen / 2))];
                 logger.log(`live playlist, switching playlist, unknown, load middle frag : ${frag.sn}`);
               }
             }


### PR DESCRIPTION
saw these index errors when debugging, e.g. for `fragLen` = 1, `Math.round(fragLen / 2)` = 1, not 0.
