### PR TITLE
Add and use generic playlist attribute list parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "minify": "uglifyjs dist/hls.js -c sequences=true,dead_code=true,conditionals=true,booleans=true,unused=true,if_return=true,join_vars=true,drop_console=true -m sort --screw-ie8 > dist/hls.min.js",
     "watch": "watchify --debug -s Hls src/hls.js -o dist/hls.js",
     "pretest": "npm run lint",
-    "test": "mocha --recursive tests/unit",
+    "test": "mocha --compilers js:babel/register --recursive tests/unit",
     "lint": "jshint src/",
     "serve": "http-server -p 8000 .",
     "open": "opener http://localhost:8000/demo/",
@@ -38,6 +38,8 @@
     "webworkify": "^1.0.2"
   },
   "devDependencies": {
+    "arraybuffer-equal": "^1.0.4",
+    "babel": "^5.8.34",
     "browserify": "^8.1.1",
     "exorcist": "^0.4.0",
     "http-server": "^0.7.4",

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -61,7 +61,7 @@ class PlaylistLoader {
       level.url = this.resolve(result[2], baseurl);
 
       Object.assign(level, level.attrs.decimalResolution('RESOLUTION'));
-      level.bitrate = level.attrs.decimalIntegerAsNumber('BANDWIDTH');
+      level.bitrate = level.attrs.decimalInteger('BANDWIDTH');
       level.name = level.attrs.quotedString('NAME');
 
       const codecs = (level.attrs.quotedString('CODECS') || '').split(',');

--- a/src/utils/attr-list.js
+++ b/src/utils/attr-list.js
@@ -13,7 +13,7 @@ class AttrList {
   decimalInteger(attrName) {
     const intValue = parseInt(this[attrName], 10);
     if (intValue > Number.MAX_SAFE_INTEGER) {
-      throw new RangeError('Value is to large to represent without loss of precision');
+      return Infinity;
     }
     return intValue;
   }
@@ -32,7 +32,7 @@ class AttrList {
   hexadecimalIntegerAsNumber(attrName) {
     const intValue = parseInt(this[attrName], 16);
     if (intValue > Number.MAX_SAFE_INTEGER) {
-      throw new RangeError('Value is to large to represent without loss of precision');
+      return Infinity;
     }
     return intValue;
   }

--- a/src/utils/attr-list.js
+++ b/src/utils/attr-list.js
@@ -1,0 +1,76 @@
+
+// adapted from https://github.com/kanongil/node-m3u8parse/blob/master/attrlist.js
+class AttrList {
+
+  constructor(attrs) {
+    if (typeof attrs === 'string') {
+      attrs = AttrList.parseAttrList(attrs);
+    }
+
+    Object.assign(this, attrs);
+  }
+
+  decimalInteger(/*attrName*/) {
+    throw new Error('Not supported');
+  }
+
+  hexadecimalInteger(attrName) {
+    let stringValue = (this[attrName] || '0x').slice(2);
+    stringValue = ((stringValue.length & 1) ? '0' : '') + stringValue;
+
+    const value = new Uint8Array(stringValue.length / 2);
+    for (let i = 0; i < stringValue.length / 2; i++) {
+      value[i] = parseInt(stringValue.slice(i * 2, i * 2 + 2), 16);
+    }
+    return value;
+  }
+
+  decimalIntegerAsNumber(attrName) {
+    const intValue = parseInt(this[attrName], 10);
+    if (intValue >= Number.MAX_VALUE) {
+      throw new RangeError('Value is to large to represent without loss of precision');
+    }
+    return intValue;
+  }
+
+  hexadecimalIntegerAsNumber(attrName) {
+    const intValue = parseInt(this[attrName], 16);
+    if (intValue >= Number.MAX_VALUE) {
+      throw new RangeError('Value is to large to represent without loss of precision');
+    }
+    return intValue;
+  }
+
+  decimalFloatingPoint(attrName) {
+    return parseFloat(this[attrName]);
+  }
+
+  quotedString(attrName) {
+    const val = this[attrName];
+    return val ? val.slice(1, -1) : undefined;
+  }
+
+  enumeratedString(attrName) {
+    return this[attrName];
+  }
+
+  decimalResolution(attrName) {
+    const res = /(\d+)x(\d+)/.exec(this[attrName]);
+    return {
+      width: res ? parseInt(res[1], 10) : null,
+      height: res ? parseInt(res[2], 10) : null,
+    };
+  }
+
+  static parseAttrList(input) {
+    const re = /(.+?)=((?:\".*?\")|.*?)(?:,|$)/g;
+    var match, attrs = {};
+    while ((match = re.exec(input)) !== null) {
+      attrs[match[1]] = match[2];
+    }
+    return attrs;
+  }
+
+}
+
+export default AttrList;

--- a/src/utils/attr-list.js
+++ b/src/utils/attr-list.js
@@ -51,10 +51,13 @@ class AttrList {
   }
 
   decimalResolution(attrName) {
-    const res = /(\d+)x(\d+)/.exec(this[attrName]);
+    const res = /^(\d+)x(\d+)$/.exec(this[attrName]);
+    if (res === null) {
+      return undefined;
+    }
     return {
-      width: res ? parseInt(res[1], 10) : null,
-      height: res ? parseInt(res[2], 10) : null,
+      width: parseInt(res[1], 10),
+      height: parseInt(res[2], 10)
     };
   }
 

--- a/src/utils/attr-list.js
+++ b/src/utils/attr-list.js
@@ -10,8 +10,12 @@ class AttrList {
     Object.assign(this, attrs);
   }
 
-  decimalInteger(/*attrName*/) {
-    throw new Error('Not supported');
+  decimalInteger(attrName) {
+    const intValue = parseInt(this[attrName], 10);
+    if (intValue > Number.MAX_SAFE_INTEGER) {
+      throw new RangeError('Value is to large to represent without loss of precision');
+    }
+    return intValue;
   }
 
   hexadecimalInteger(attrName) {
@@ -25,17 +29,9 @@ class AttrList {
     return value;
   }
 
-  decimalIntegerAsNumber(attrName) {
-    const intValue = parseInt(this[attrName], 10);
-    if (intValue >= Number.MAX_VALUE) {
-      throw new RangeError('Value is to large to represent without loss of precision');
-    }
-    return intValue;
-  }
-
   hexadecimalIntegerAsNumber(attrName) {
     const intValue = parseInt(this[attrName], 16);
-    if (intValue >= Number.MAX_VALUE) {
+    if (intValue > Number.MAX_SAFE_INTEGER) {
       throw new RangeError('Value is to large to represent without loss of precision');
     }
     return intValue;

--- a/tests/unit/utils/attr-list.js
+++ b/tests/unit/utils/attr-list.js
@@ -1,0 +1,95 @@
+const assert = require('assert');
+const bufferIsEqual = require('arraybuffer-equal');
+
+import AttrList from '../../../src/utils/attr-list';
+
+describe('AttrList', () => {
+  it('constructor() supports empty arguments', () => {
+    assert.deepEqual(new AttrList(), {});
+    assert.deepEqual(new AttrList({}), {});
+    assert.deepEqual(new AttrList(undefined), {});
+  });
+  it('constructor() supports object argument', () => {
+    const obj = { VALUE: "42" };
+    const list = new AttrList(obj);
+    assert.strictEqual(list.decimalInteger('VALUE'), 42);
+    assert.strictEqual(Object.keys(list).length, 1);
+  });
+
+  it('parses valid decimalInteger attribute', () => {
+    assert.strictEqual(new AttrList('INT=42').decimalInteger('INT'), 42);
+    assert.strictEqual(new AttrList('INT=0').decimalInteger('INT'), 0);
+  });
+  it('parses valid hexadecimalInteger attribute', () => {
+    assert.strictEqual(new AttrList('HEX=0x42').hexadecimalIntegerAsNumber('HEX'), 0x42);
+    assert.strictEqual(new AttrList('HEX=0X42').hexadecimalIntegerAsNumber('HEX'), 0x42);
+    assert.strictEqual(new AttrList('HEX=0x0').hexadecimalIntegerAsNumber('HEX'), 0);
+  });
+  it('parses valid decimalFloatingPoint attribute', () => {
+    assert.strictEqual(new AttrList('FLOAT=0.42').decimalFloatingPoint('FLOAT'), 0.42);
+    assert.strictEqual(new AttrList('FLOAT=-0.42').decimalFloatingPoint('FLOAT'), -0.42);
+    assert.strictEqual(new AttrList('FLOAT=0').decimalFloatingPoint('FLOAT'), 0);
+  });
+  it('parses valid quotedString attribute', () => {
+    assert.strictEqual(new AttrList('STRING="hi"').quotedString('STRING'), 'hi');
+    assert.strictEqual(new AttrList('STRING=""').quotedString('STRING'), '');
+  });
+  it('parses exotic quotedString attribute', () => {
+    const list = new AttrList('STRING="hi,ENUM=OK,RES=4x2"');
+    assert.strictEqual(list.quotedString('STRING'), 'hi,ENUM=OK,RES=4x2');
+    assert.strictEqual(Object.keys(list).length, 1);
+  });
+  it('parses valid enumeratedString attribute', () => {
+    assert.strictEqual(new AttrList('ENUM=OK').enumeratedString('ENUM'), 'OK');
+  });
+  it('parses exotic quotedString attribute', () => {
+    assert.strictEqual(new AttrList('ENUM=1').enumeratedString('ENUM'), '1');
+    assert.strictEqual(new AttrList('ENUM=A=B').enumeratedString('ENUM'), 'A=B');
+    assert.strictEqual(new AttrList('ENUM=A=B=C').enumeratedString('ENUM'), 'A=B=C');
+    const list = new AttrList('ENUM1=A=B=C,ENUM2=42');
+    assert.strictEqual(list.enumeratedString('ENUM1'), 'A=B=C');
+    assert.strictEqual(list.enumeratedString('ENUM2'), '42');
+  });
+  it('parses valid decimalResolution attribute', () => {
+    assert.deepStrictEqual(new AttrList('RES=400x200').decimalResolution('RES'), { width:400, height:200 });
+    assert.deepStrictEqual(new AttrList('RES=0x0').decimalResolution('RES'), { width:0, height:0 });
+  });
+
+  it('parses multiple attributes', () => {
+    const list = new AttrList('INT=42,HEX=0x42,FLOAT=0.42,STRING="hi",ENUM=OK,RES=4x2');
+    assert.strictEqual(list.decimalInteger('INT'), 42);
+    assert.strictEqual(list.hexadecimalIntegerAsNumber('HEX'), 0x42);
+    assert.strictEqual(list.decimalFloatingPoint('FLOAT'), 0.42);
+    assert.strictEqual(list.quotedString('STRING'), 'hi');
+    assert.strictEqual(list.enumeratedString('ENUM'), 'OK');
+    assert.deepStrictEqual(list.decimalResolution('RES'), { width:4, height:2 });
+    assert.strictEqual(Object.keys(list).length, 6);
+  });
+
+  it('parses dashed attribute names', () => {
+    const list = new AttrList('INT-VALUE=42,H-E-X=0x42,-FLOAT=0.42,STRING-="hi",ENUM=OK');
+    assert.strictEqual(list.decimalInteger('INT-VALUE'), 42);
+    assert.strictEqual(list.hexadecimalIntegerAsNumber('H-E-X'), 0x42);
+    assert.strictEqual(list.decimalFloatingPoint('-FLOAT'), 0.42);
+    assert.strictEqual(list.quotedString('STRING-'), 'hi');
+    assert.strictEqual(list.enumeratedString('ENUM'), 'OK');
+    assert.strictEqual(Object.keys(list).length, 5);
+  });
+
+  it('handles hexadecimalInteger conversions', () => {
+    const list = new AttrList('HEX1=0x0123456789abcdef0123456789abcdef,HEX2=0x123,HEX3=0x0');
+    assert(bufferIsEqual(list.hexadecimalInteger('HEX1').buffer, new Uint8Array([0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef]).buffer));
+    assert(bufferIsEqual(list.hexadecimalInteger('HEX2').buffer, new Uint8Array([0x01,0x23]).buffer));
+    assert(bufferIsEqual(list.hexadecimalInteger('HEX3').buffer, new Uint8Array([0x0]).buffer));
+  });
+
+  it('throws on large number conversions', () => {
+    const list = new AttrList('VAL=12345678901234567890,HEX=0x0123456789abcdef0123456789abcdef');
+    assert.throws(() => {
+      list.decimalInteger('VAL');
+    }, RangeError);
+    assert.throws(() => {
+      list.hexadecimalIntegerAsNumber('HEX');
+    }, RangeError);
+  });
+});  

--- a/tests/unit/utils/attr-list.js
+++ b/tests/unit/utils/attr-list.js
@@ -83,13 +83,9 @@ describe('AttrList', () => {
     assert(bufferIsEqual(list.hexadecimalInteger('HEX3').buffer, new Uint8Array([0x0]).buffer));
   });
 
-  it('throws on large number conversions', () => {
+  it('returns infinity on large number conversions', () => {
     const list = new AttrList('VAL=12345678901234567890,HEX=0x0123456789abcdef0123456789abcdef');
-    assert.throws(() => {
-      list.decimalInteger('VAL');
-    }, RangeError);
-    assert.throws(() => {
-      list.hexadecimalIntegerAsNumber('HEX');
-    }, RangeError);
+    assert.strictEqual(list.decimalInteger('VAL'), Infinity);
+    assert.strictEqual(list.hexadecimalIntegerAsNumber('HEX'), Infinity);
   });
 });  

--- a/tests/unit/utils/attr-list.js
+++ b/tests/unit/utils/attr-list.js
@@ -42,7 +42,7 @@ describe('AttrList', () => {
   it('parses valid enumeratedString attribute', () => {
     assert.strictEqual(new AttrList('ENUM=OK').enumeratedString('ENUM'), 'OK');
   });
-  it('parses exotic quotedString attribute', () => {
+  it('parses exotic enumeratedString attribute', () => {
     assert.strictEqual(new AttrList('ENUM=1').enumeratedString('ENUM'), '1');
     assert.strictEqual(new AttrList('ENUM=A=B').enumeratedString('ENUM'), 'A=B');
     assert.strictEqual(new AttrList('ENUM=A=B=C').enumeratedString('ENUM'), 'A=B=C');
@@ -54,6 +54,15 @@ describe('AttrList', () => {
     assert.deepStrictEqual(new AttrList('RES=400x200').decimalResolution('RES'), { width:400, height:200 });
     assert.deepStrictEqual(new AttrList('RES=0x0').decimalResolution('RES'), { width:0, height:0 });
   });
+  it('handles invalid decimalResolution attribute', () => {
+    assert.deepStrictEqual(new AttrList('RES=400x-200').decimalResolution('RES'), undefined);
+    assert.deepStrictEqual(new AttrList('RES=400.5x200').decimalResolution('RES'), undefined);
+    assert.deepStrictEqual(new AttrList('RES=400x200.5').decimalResolution('RES'), undefined);
+    assert.deepStrictEqual(new AttrList('RES=400').decimalResolution('RES'), undefined);
+    assert.deepStrictEqual(new AttrList('RES=400x').decimalResolution('RES'), undefined);
+    assert.deepStrictEqual(new AttrList('RES=x200').decimalResolution('RES'), undefined);
+    assert.deepStrictEqual(new AttrList('RES=x').decimalResolution('RES'), undefined);
+  });
 
   it('parses multiple attributes', () => {
     const list = new AttrList('INT=42,HEX=0x42,FLOAT=0.42,STRING="hi",ENUM=OK,RES=4x2');
@@ -64,6 +73,17 @@ describe('AttrList', () => {
     assert.strictEqual(list.enumeratedString('ENUM'), 'OK');
     assert.deepStrictEqual(list.decimalResolution('RES'), { width:4, height:2 });
     assert.strictEqual(Object.keys(list).length, 6);
+  });
+
+  it('handles missing attributes', () => {
+    const list = new AttrList();
+    assert(isNaN(list.decimalInteger('INT')));
+    assert(isNaN(list.hexadecimalIntegerAsNumber('HEX')));
+    assert(isNaN(list.decimalFloatingPoint('FLOAT')));
+    assert.strictEqual(list.quotedString('STRING'), undefined);
+    assert.strictEqual(list.enumeratedString('ENUM'), undefined);
+    assert.strictEqual(list.decimalResolution('RES'), undefined);
+    assert.strictEqual(Object.keys(list).length, 0);
   });
 
   it('parses dashed attribute names', () => {


### PR DESCRIPTION
This fixes order dependent parsing of `EXT-X-STREAM-INF` attributes.

This also exposes any stream info attribute for external processing.

Tested to work on a normal and encrypted stream in Chrome.