### PR TITLE
Parse and use sample aspect ratio information

### DIFF
--- a/src/demux/exp-golomb.js
+++ b/src/demux/exp-golomb.js
@@ -162,6 +162,7 @@ class ExpGolomb {
       frameCropRightOffset = 0,
       frameCropTopOffset = 0,
       frameCropBottomOffset = 0,
+      sarScale = 1,
       profileIdc,profileCompat,levelIdc,
       numRefFramesInPicOrderCntCycle, picWidthInMbsMinus1,
       picHeightInMapUnitsMinus1,
@@ -227,8 +228,41 @@ class ExpGolomb {
       frameCropTopOffset = this.readUEG();
       frameCropBottomOffset = this.readUEG();
     }
+    if (this.readBoolean()) {
+      // vui_parameters_present_flag
+      if (this.readBoolean()) {
+        // aspect_ratio_info_present_flag
+        let sarRatio;
+        const aspectRatioIdc = this.readUByte();
+        switch (aspectRatioIdc) {
+          //case 1: sarRatio = [1,1]; break;
+          case 2: sarRatio = [12,11]; break;
+          case 3: sarRatio = [10,11]; break;
+          case 4: sarRatio = [16,11]; break;
+          case 5: sarRatio = [40,33]; break;
+          case 6: sarRatio = [24,11]; break;
+          case 7: sarRatio = [20,11]; break;
+          case 8: sarRatio = [32,11]; break;
+          case 9: sarRatio = [80,33]; break;
+          case 10: sarRatio = [18,11]; break;
+          case 11: sarRatio = [15,11]; break;
+          case 12: sarRatio = [64,33]; break;
+          case 13: sarRatio = [160,99]; break;
+          case 14: sarRatio = [4,3]; break;
+          case 15: sarRatio = [3,2]; break;
+          case 16: sarRatio = [2,1]; break;
+          case 255: {
+            sarRatio = [this.readUByte() << 8 | this.readUByte(), this.readUByte() << 8 | this.readUByte()];
+            break;
+          }
+        }
+        if (sarRatio) {
+          sarScale = sarRatio[0] / sarRatio[1];
+        }
+      }
+    }
     return {
-      width: ((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2,
+      width: (((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2) * sarScale,
       height: ((2 - frameMbsOnlyFlag) * (picHeightInMapUnitsMinus1 + 1) * 16) - (frameCropTopOffset * 2) - (frameCropBottomOffset * 2)
     };
   }


### PR DESCRIPTION
This fixes display of videos with non square aspect ratio.

Values are copied from **Table E-1** in the H.264 spec.