### PR TITLE
Prevent tick() handler from being entered while already processing

### DIFF
--- a/src/controller/mse-media-controller.js
+++ b/src/controller/mse-media-controller.js
@@ -28,6 +28,7 @@ class MSEMediaController {
     this.config = hls.config;
     this.audioCodecSwap = false;
     this.hls = hls;
+    this.ticks = 0;
     // Source Buffer listeners
     this.onsbue = this.onSBUpdateEnd.bind(this);
     this.onsbe  = this.onSBUpdateError.bind(this);
@@ -136,6 +137,17 @@ class MSEMediaController {
   }
 
   tick() {
+    this.ticks++;
+    if (this.ticks === 1) {
+      this.doTick();
+      if (this.ticks > 1) {
+        setTimeout(this.tick, 1);
+      }
+      this.ticks = 0;
+    }
+  }
+
+  doTick() {
     var pos, level, levelDetails, hls = this.hls;
     switch(this.state) {
       case State.ERROR:


### PR DESCRIPTION
The loose event coupling means that `tick()` can easily be called while processing a `tick()`. This can lead to all sorts of weird behavior.

I am aware of at least one case where this happens: When loading a key which has already been loaded, the `onKeyLoaded` callback is called synchronously while a tick is processing, triggering another `tick()`.