### PR TITLE
lowered threshold for audio overlap in remuxer

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -277,7 +277,7 @@ class MP4Remuxer {
         dtsnorm = this._PTSNormalize(dts, nextAacPts);
         delta = Math.round(1000 * (ptsnorm - nextAacPts) / pesTimeScale);
         // if fragment are contiguous, or delta less than 600ms, ensure there is no overlap/hole between fragments
-        if (contiguous || Math.abs(delta) < 600) {
+        if (contiguous || Math.abs(delta) < 50) {
           // log delta
           if (delta) {
             if (delta > 1) {


### PR DESCRIPTION
Hi @mangui  thanks again for your suggestion. It seems like lowering the threshold for the overlap detection does the trick and fixes the bug #147 - does this seem like a reasonable solution for you or does it have any drawbacks. I have used a 50ms threshold as the error message was talking about this value.