### PR TITLE
Fixes api documentation for LEVEL_SWITCH

### DIFF
--- a/API.md
+++ b/API.md
@@ -499,7 +499,7 @@ full list of Events available below :
   - `Hls.Events.LEVEL_PTS_UPDATED`  - fired when a level's PTS information has been updated after parsing a fragment
     -  data: { details : levelDetails object, level : id of updated level, drift: PTS drift observed when parsing last fragment }
   - `Hls.Events.LEVEL_SWITCH`  - fired when a level switch is requested
-    -  data: { levelId : id of new level }
+    -  data: { level : id of new level, it is the index of the array `Hls.levels` }
   - `Hls.Events.KEY_LOADING`  - fired when a decryption key loading starts
     -  data: { frag : fragment object}
   - `Hls.Events.KEY_LOADED`  - fired when a decryption key loading is completed


### PR DESCRIPTION
The parameter name is level not levelid (just by looking at https://github.com/dailymotion/hls.js/blob/60e7c82edaa77c7b27b82011dd435c3f63b423cc/src/controller/level-controller.js#L123)