### PR TITLE
Change mimetype for audio sourceBuffers to "audio/mp4"

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -60,11 +60,12 @@ class LevelController extends EventHandler {
 
     // only keep level with supported audio/video codecs
     levels = levels.filter(function(level) {
-      var checkSupported = function(codec) { return MediaSource.isTypeSupported(`video/mp4;codecs=${codec}`);};
+      var checkSupportedAudio = function(codec) { return MediaSource.isTypeSupported(`audio/mp4;codecs=${codec}`);};
+      var checkSupportedVideo = function(codec) { return MediaSource.isTypeSupported(`video/mp4;codecs=${codec}`);};
       var audioCodec = level.audioCodec, videoCodec = level.videoCodec;
 
-      return (!audioCodec || checkSupported(audioCodec)) &&
-             (!videoCodec || checkSupported(videoCodec));
+      return (!audioCodec || checkSupportedAudio(audioCodec)) &&
+             (!videoCodec || checkSupportedVideo(videoCodec));
     });
 
     if(levels.length) {

--- a/src/controller/mse-media-controller.js
+++ b/src/controller/mse-media-controller.js
@@ -1076,7 +1076,7 @@ class MSEMediaController extends EventHandler {
         logger.log(`selected A/V codecs for sourceBuffers:${audioCodec},${videoCodec}`);
         // create source Buffer and link them to MediaSource
         if (audioCodec) {
-          sb = this.sourceBuffer.audio = this.mediaSource.addSourceBuffer(`video/mp4;codecs=${audioCodec}`);
+          sb = this.sourceBuffer.audio = this.mediaSource.addSourceBuffer(`audio/mp4;codecs=${audioCodec}`);
           sb.addEventListener('updateend', this.onsbue);
           sb.addEventListener('error', this.onsbe);
         }


### PR DESCRIPTION
Tested working on Chrome Canary (v50) and Firefox (v42) on OSX.

Tested by using Big Buck Bunny from demo page and an audio-only stream that I put on pastebin since I could not find any working public audio-only stream: http://pastebin.com/raw/dpXTqA29 (requires disabling web security / CORS checking in browser)
Additional testing using W3C test case: http://w3c-test.org/media-source/mediasource-addsourcebuffer.html. This does not actually play out audio/video, but it queries the browser using isTypeSupported with mime type that starts with `audio/mp4`.

If someone is able to verify this with IE and perhaps other browsers on Windows, this would resolve #203.