### PR TITLE
Fix bug in url util which meant url calculated incorrectly when traversing up to root

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -46,8 +46,7 @@ var URLHelper = {
       builtURL = baseURLDomain+URLHelper.buildAbsolutePath('', relativeURL.substring(1));
     }
     else {
-      var newPath = URLHelper.buildAbsolutePath(baseURLPath, relativeURL);
-      builtURL = baseURLDomain + newPath;
+      builtURL = URLHelper.buildAbsolutePath(baseURLDomain+baseURLPath, relativeURL);
     }
 
     // put the query and hash parts back

--- a/tests/unit/utils/url.js
+++ b/tests/unit/utils/url.js
@@ -32,8 +32,10 @@ describe('utils', function() {
       e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "../z.ts?abc=1#test"), "https://a.com/b/z.ts?abc=1#test");
       e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "./../z.ts?abc=1#test"), "https://a.com/b/z.ts?abc=1#test");
       e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "././z.ts?abc=1#test"), "https://a.com/b/cd/z.ts?abc=1#test");
-      e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "../../z.ts?abc=1#test"), "https://a.com/b/z.ts?abc=1#test");
-      e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "../../z.ts?abc=1&something=blah/./../test#test"), "https://a.com/b/z.ts?abc=1&something=blah/./../test#test");
+      e(fn("https://a.com/b/cd/e/f.m3u8?test=1#something", "../../z.ts?abc=1#test"), "https://a.com/b/z.ts?abc=1#test");
+      e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "../../z.ts?abc=1#test"), "https://a.com/z.ts?abc=1#test");
+      e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "../../z.ts?abc=1&something=blah/./../test#test"), "https://a.com/z.ts?abc=1&something=blah/./../test#test");
+      e(fn("https://a.com/b/cd/e/f.m3u8?test=1#something", "./../../z.ts?abc=1#test"), "https://a.com/b/z.ts?abc=1#test");
 
       e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "subdir/pointless/../z.ts?abc=1#test"), "https://a.com/b/cd/subdir/z.ts?abc=1#test");
       e(fn("https://a.com/b/cd/e.m3u8?test=1#something", "/subdir/pointless/../z.ts?abc=1#test"), "https://a.com/subdir/z.ts?abc=1#test");


### PR DESCRIPTION
Also fixed the faulty test and added some more.

(fixes #207)

The issue was that
```javascript
buildAbsolutePath("a/b/c.m3y8", "../d.m3u8");
```
and 
```javascript
buildAbsolutePath("a/b/c.m3y8", "../../d.m3u8");
```
both returned `a/d.m3u8`. `buildAbsolutePath` doesn't handle the base url becoming completely empty.

Now the base url for `buildAbsolutePath` also includes the domain which fixes this.