### PR TITLE
Buffer events 

### DIFF
--- a/src/controller/mse-media-controller.js
+++ b/src/controller/mse-media-controller.js
@@ -11,18 +11,17 @@ import LevelHelper from '../helper/level-helper';
 import {ErrorTypes, ErrorDetails} from '../errors';
 
 const State = {
-  ERROR : -2,
-  STARTING : -1,
-  IDLE : 0,
-  KEY_LOADING : 1,
-  FRAG_LOADING : 2,
-  FRAG_LOADING_WAITING_RETRY : 3,
-  WAITING_LEVEL : 4,
-  PARSING : 5,
-  PARSED : 6,
-  APPENDING : 7,
-  BUFFER_FLUSHING : 8,
-  ENDED : 9
+  ERROR : 'ERROR',
+  STARTING : 'STARTING',
+  IDLE : 'IDLE',
+  KEY_LOADING : 'KEY_LOADING',
+  FRAG_LOADING : 'FRAG_LOADING',
+  FRAG_LOADING_WAITING_RETRY : 'FRAG_LOADING_WAITING_RETRY',
+  WAITING_LEVEL : 'WAITING_LEVEL',
+  PARSING : 'PARSING',
+  PARSED : 'PARSED',
+  APPENDING : 'APPENDING',
+  ENDED : 'ENDED'
 };
 
 class MSEMediaController extends EventHandler {
@@ -276,21 +275,8 @@ class MSEMediaController extends EventHandler {
                 } else {
                   // have we reached end of VOD playlist ?
                   if (!levelDetails.live) {
-                    var mediaSource = this.mediaSource;
-                    if (mediaSource) {
-                      switch(mediaSource.readyState) {
-                        case 'open':
-                          this.hls.trigger(Event.BUFFER_EOS);
-                          this.state = State.ENDED;
-                          break;
-                        case 'ended':
-                          logger.log('all media data available and mediaSource ended, stop loading fragment');
-                          this.state = State.ENDED;
-                          break;
-                        default:
-                          break;
-                      }
-                    }
+                    this.hls.trigger(Event.BUFFER_EOS);
+                    this.state = State.ENDED;
                   }
                   frag = null;
                 }
@@ -446,33 +432,6 @@ class MSEMediaController extends EventHandler {
           // sourceBuffer undefined, switch back to IDLE state
           this.state = State.IDLE;
         }
-        break;
-      case State.BUFFER_FLUSHING:
-        // loop through all buffer ranges to flush
-        while(this.flushRange.length) {
-          var range = this.flushRange[0];
-          // flushBuffer will abort any buffer append in progress and flush Audio/Video Buffer
-          if (this.flushBuffer(range.start, range.end)) {
-            // range flushed, remove from flush array
-            this.flushRange.shift();
-          } else {
-            // flush in progress, come back later
-            break;
-          }
-        }
-        if (this.flushRange.length === 0) {
-          // handle end of immediate switching if needed
-          if (this.immediateSwitch) {
-            this.immediateLevelSwitchEnd();
-          }
-          // move to IDLE once flush complete. this should trigger new fragment loading
-          this.state = State.IDLE;
-          // reset reference to frag
-          this.fragPrevious = null;
-        }
-         /* if not everything flushed, stay in BUFFER_FLUSHING state. we will come back here
-            each time sourceBuffer updateend() callback will be triggered
-            */
         break;
       case State.ENDED:
         break;
@@ -723,10 +682,7 @@ class MSEMediaController extends EventHandler {
     }
     this.fragCurrent = null;
     // flush everything
-    this.flushBufferCounter = 0;
-    this.flushRange.push({start: 0, end: Number.POSITIVE_INFINITY});
-    // trigger a sourceBuffer flush
-    this.state = State.BUFFER_FLUSHING;
+    this.hls.trigger(Event.BUFFER_FLUSHING, {startOffset: 0, endOffset: Number.POSITIVE_INFINITY});
     // increase fragment load Index to avoid frag loop loading error after buffer flush
     this.fragLoadIdx += 2 * this.config.fragLoadingLoopThreshold;
     // speed up switching, trigger timer function
@@ -757,7 +713,7 @@ class MSEMediaController extends EventHandler {
     if (currentRange) {
     // flush buffer preceding current fragment (flush until current fragment start offset)
     // minus 1s to avoid video freezing, that could happen if we flush keyframe of current video ...
-      this.flushRange.push({start: 0, end: currentRange.start - 1});
+      this.hls.trigger(Event.BUFFER_FLUSHING, {startOffset: 0, endOffset: currentRange.start - 1});
     }
     if (!this.media.paused) {
       // add a safety delay of 1s
@@ -778,23 +734,16 @@ class MSEMediaController extends EventHandler {
       nextRange = this.followingBufferRange(nextRange);
       if (nextRange) {
         // flush position is the start position of this new buffer
-        this.flushRange.push({start: nextRange.start, end: Number.POSITIVE_INFINITY});
+        this.hls.trigger(Event.BUFFER_FLUSHING, {startOffset: nextRange.start, endOffset: Number.POSITIVE_INFINITY});
         // if we are here, we can also cancel any loading/demuxing in progress, as they are useless
         var fragCurrent = this.fragCurrent;
         if (fragCurrent && fragCurrent.loader) {
           fragCurrent.loader.abort();
         }
         this.fragCurrent = null;
+        // increase fragment load Index to avoid frag loop loading error after buffer flush
+        this.fragLoadIdx += 2 * this.config.fragLoadingLoopThreshold;
       }
-    }
-    if (this.flushRange.length) {
-      this.flushBufferCounter = 0;
-      // trigger a sourceBuffer flush
-      this.state = State.BUFFER_FLUSHING;
-      // increase fragment load Index to avoid frag loop loading error after buffer flush
-      this.fragLoadIdx += 2 * this.config.fragLoadingLoopThreshold;
-      // speed up switching, trigger timer function
-      this.tick();
     }
   }
 
@@ -1241,6 +1190,10 @@ _checkBuffer() {
 
   onSBUpdateEnd() {
 
+    if (this._needsFlush) {
+      this.doFlush();
+    }
+
     if (this._needsEos) {
       this.onBufferEOS();
     }
@@ -1338,8 +1291,9 @@ _checkBuffer() {
     this.hls.trigger(Event.ERROR, {type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.BUFFER_APPENDING_ERROR, fatal: false, frag: this.fragCurrent});
   }
 
-  onBufferEOS() {
+  onBufferEos() {
     var sb = this.sourceBuffer;
+    if (!this.mediaSource || this.mediaSource.readyState !== 'open') return;
     if (!((sb.audio && sb.audio.updating) || (sb.video && sb.video.updating))) {
       logger.log('all media data available, signal endOfStream() to MediaSource and stop loading fragment');
       //Notify the media element that it now has all of the media data
@@ -1348,6 +1302,43 @@ _checkBuffer() {
     } else {
       this._needsEos = true;
     }
+  }
+
+  onBufferFlushing(data) {
+    this.flushRange.push({start: data.startOffset, end: data.endOffset});
+    // attempt flush immediatly
+    this.flushBufferCounter = 0;
+    this.doFlush();
+  }
+
+  doFlush() {
+    // loop through all buffer ranges to flush
+    while(this.flushRange.length) {
+      var range = this.flushRange[0];
+      // flushBuffer will abort any buffer append in progress and flush Audio/Video Buffer
+      if (this.flushBuffer(range.start, range.end)) {
+        // range flushed, remove from flush array
+        this.flushRange.shift();
+      } else {
+        this._needsFlush = true;
+      }
+    }
+    if (this.flushRange.length === 0) {
+      // everything flushed
+      this._needsFlush = false;
+      this.hls.trigger(Event.BUFFER_FLUSHED);
+    }
+  }
+
+  onBufferFlushed() {
+    // handle end of immediate switching if needed
+    if (this.immediateSwitch) {
+      this.immediateLevelSwitchEnd();
+    }
+    // move to IDLE once flush complete. this should trigger new fragment loading
+    this.state = State.IDLE;
+    // reset reference to frag
+    this.fragPrevious = null;
   }
 
 }

--- a/src/controller/mse-media-controller.js
+++ b/src/controller/mse-media-controller.js
@@ -1154,7 +1154,7 @@ _checkBuffer() {
   }
 
   onSBUpdateError(event) {
-    this.hls.trigger(Event.BUFFER_APPEND_FAIL);
+    this.hls.trigger(Event.BUFFER_APPEND_FAIL, {event: event});
   }
 
   // implement these in specific class
@@ -1236,8 +1236,8 @@ _checkBuffer() {
     this.tick();
   }
 
-  onBufferAppendFail() {
-    logger.error(`sourceBuffer error:${event}`);
+  onBufferAppendFail(data) {
+    logger.error(`sourceBuffer error:${data.event}`);
     this.state = State.ERROR;
     // according to http://www.w3.org/TR/media-source/#sourcebuffer-append-error
     // this error might not always be fatal (it is fatal if decode error is set, in that case
@@ -1247,7 +1247,9 @@ _checkBuffer() {
 
   onBufferEos() {
     var sb = this.sourceBuffer;
-    if (!this.mediaSource || this.mediaSource.readyState !== 'open') return;
+    if (!this.mediaSource || this.mediaSource.readyState !== 'open') {
+      return;
+    }
     if (!((sb.audio && sb.audio.updating) || (sb.video && sb.video.updating))) {
       logger.log('all media data available, signal endOfStream() to MediaSource and stop loading fragment');
       //Notify the media element that it now has all of the media data

--- a/src/events.js
+++ b/src/events.js
@@ -3,7 +3,7 @@ module.exports = {
   BUFFER_CODECS: 'hlsBufferCodecs',
   // when we append a segment to the buffer - data: { segment: segment object }
   BUFFER_APPENDING: 'hlsBufferAppending',
-  // when buffer appending fails - data: { segment: segment object, type : error type, details : error details, fatal : if true, hls.js cannot/will not try to recover, if false, hls.js will try to recover,other error specific data}
+  // when buffer appending fails - data: {event: native error event}
   BUFFER_APPEND_FAIL: 'hlsBufferAppendFail',
   // when we are done with appending a media segment to the buffer
   BUFFER_APPENDED: 'hlsBufferAppended',

--- a/src/events.js
+++ b/src/events.js
@@ -1,4 +1,18 @@
 module.exports = {
+  // when we know about the codecs that we need buffers for to push into - data: {audioCodec, videoCodec}
+  BUFFER_CODECS: 'hlsBufferCodecs',
+  // when we append a segment to the buffer - data: { segment: segment object }
+  BUFFER_APPENDING: 'hlsBufferAppending',
+  // when buffer appending fails - data: { segment: segment object, type : error type, details : error details, fatal : if true, hls.js cannot/will not try to recover, if false, hls.js will try to recover,other error specific data}
+  BUFFER_APPEND_FAIL: 'hlsBufferAppendFail',
+  // when we are done with appending a media segment to the buffer
+  BUFFER_APPENDED: 'hlsBufferAppended',
+  // when the stream is finished and we want to notify the media buffer that there will be no more data
+  BUFFER_EOS: 'hlsBufferEos',
+  // when the media buffer should be flushed - data {startOffset, endOffset}
+  BUFFER_FLUSHING: 'hlsBufferFlushing',
+  // when the media has been flushed
+  BUFFER_FLUSHED: 'hlsBufferFlushed',
   // fired before MediaSource is attaching to media element - data: { media }
   MEDIA_ATTACHING: 'hlsMediaAttaching',
   // fired when MediaSource has been succesfully attached to media element - data: { }


### PR DESCRIPTION
@mangui This is introducing the new buffer events and separates MSE buffering and HLS scheduling concerns into separate functions. 

Most important is that the streaming state machine does not run the appending anymore, it's all done via the buffer events and SourceBuffer ended callback. Same for the flushing.

There is still some shared state across the functions caring of MSE buffering (only in `doAppending` actually for the error state), but it should not be too hard to cleanly isolate that now.

Essentially all the logic has just been copy-pasted around, and in some place the state setup has been simply called before or after the event triggers, but I checked and there is no shared state in these cases between the state machine and the buffer event handlers.

The other important part is that we are doing the flushing, EOS and appending all async now, dispatched to the MSE callbacks if necessary when the SB is busy (see respective flags).