### PR TITLE
adding empty closed caption object for aac demuxing

### DIFF
--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -83,7 +83,7 @@ import ID3 from '../demux/id3';
         break;
       }
     }
-    this.remuxer.remux(this._aacTrack,{samples : []}, {samples : [ { pts: pts, dts : pts, unit : id3.payload} ]}, timeOffset);
+    this.remuxer.remux(this._aacTrack,{samples : []}, {samples : [ { pts: pts, dts : pts, unit : id3.payload} ]}, { samples: [] }, timeOffset);
   }
 
   destroy() {


### PR DESCRIPTION
The mp4 remuxer has a parameter for a textTrack. When attempting to use an AAC stream the demuxer passes the timeOffset is into this value. This causes errors when attempting to load an AAC stream, as textTrack.samples will be undefined. Specifically mp4-remuxer.js:53 will fail with a 'cannot call length of undefined' error. 

This PR fixes that by supplying a dummy textTrack object to the remuxer function.