### PR TITLE
Fix readSPS issues

### DIFF
--- a/src/demux/exp-golomb.js
+++ b/src/demux/exp-golomb.js
@@ -276,7 +276,7 @@ class ExpGolomb {
       }
     }
     return {
-      width: (((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2) * sarScale,
+      width: Math.ceil((((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2) * sarScale),
       height: ((2 - frameMbsOnlyFlag) * (picHeightInMapUnitsMinus1 + 1) * 16) - ((frameMbsOnlyFlag? 2 : 4) * (frameCropTopOffset + frameCropBottomOffset))
     };
   }

--- a/src/demux/exp-golomb.js
+++ b/src/demux/exp-golomb.js
@@ -249,7 +249,7 @@ class ExpGolomb {
         let sarRatio;
         const aspectRatioIdc = this.readUByte();
         switch (aspectRatioIdc) {
-          //case 1: sarRatio = [1,1]; break;
+          case 1: sarRatio = [1,1]; break;
           case 2: sarRatio = [12,11]; break;
           case 3: sarRatio = [10,11]; break;
           case 4: sarRatio = [16,11]; break;


### PR DESCRIPTION
I encountered some strange issues with some filmon.tv streams

Since commit 4556b434a0f0e3f8e6d61ba6e45176157518f6f5, I am getting an error from the html5 element, yet no HLS.js ERROR event emitted.

I traced the reason to be getting a sarRatio of `[1280, 1281]`, which causes an irregular 0.999.. sarScale, which makes the width a floating point number.

It seems that when using a floating-point width, an error is emitted (in runtime Electron v0.33.9) without any HLS.js ERROR event. I cannot debug this further to find why the error is emitted, **but since the width reflects pixel-width, I figured that it should be an integer anyway** and I `Math.ceil`'d it.

I also enabled handling of the 1:1 case