### PR TITLE
Update Firefox compatibility info

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ as of today, it is supported on:
 
  * Chrome for Android 34+
  * Chrome for Desktop 34+
- * Firefox for Desktop 38+ (with ```media.mediasource.whitelist=false``` in about:config)
+ * Firefox for Android 41+
+ * Firefox for Desktop 42+
  * IE11+ for Windows 8.1
  * Safari for Mac 8+ (beta)
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/MediaSource, the `media.mediasource.whitelist` preference was removed in Firefox 42.
MSE was enabled in Firefox 41 without the preference.