### PR TITLE
Include compiled index.js in npm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "bugs": {
     "url": "https://github.com/dailymotion/hls.js/issues"
   },
-  "main": "./lib/hls.js",
+  "main": "./lib/index.js",
   "private": false,
   "scripts": {
     "clean": "find dist -mindepth 1 -delete",
     "prebuild": "npm run clean & npm run test",
-    "build": "npm run babel && browserify -t [babelify] -s Hls index.js --debug | exorcist dist/hls.js.map -b . > dist/hls.js",
+    "build": "npm run babel && browserify -t [babelify] -s Hls src/index.js --debug | exorcist dist/hls.js.map -b . > dist/hls.js",
     "postbuild": "npm run minify",
     "prerelease": "npm run prebuild && npm run build && npm run postbuild && git add dist/* && git commit -m 'update dist'",
     "patch": "npm run prerelease && mversion p",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 // This is mostly for support of the es6 module export
 // syntax with the babel compiler, it looks like it doesnt support
 // function exports like we are used to in node/commonjs
-module.exports = require('./src/hls.js').default;
+module.exports = require('./hls.js').default;


### PR DESCRIPTION
So that this module can bundled with webpack / browserify when installed
from npm.

Should fix #240