### PR TITLE
CEA-708 improvements

### DIFF
--- a/src/hls.js
+++ b/src/hls.js
@@ -71,7 +71,10 @@ class Hls {
           bufferController : BufferController,
           streamController: StreamController,
           timelineController: TimelineController,
-          enableCEA708Captions: true,
+          cea708Enabled: true,
+          cea708MaxDisplayTime: 30,
+          cea708MinDisplayTime: 3,
+          cea708AllowedOverlapTime: 0.5,
           enableMP2TPassThrough : false
         };
     }

--- a/src/utils/cea-708-interpreter.js
+++ b/src/utils/cea-708-interpreter.js
@@ -2,27 +2,135 @@
  * CEA-708 interpreter
 */
 
+// Basic North American 608 CC char set, mostly ASCII. Indexed by (char-0x20).
+const BASIC_CHARACTER_SET = [
+  0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,     //   ! " # $ % & '
+  0x28, 0x29,                                         // ( )
+  0xE1,       // 2A: 225 'á' "Latin small letter A with acute"
+  0x2B, 0x2C, 0x2D, 0x2E, 0x2F,                       //       + , - . /
+  0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,     // 0 1 2 3 4 5 6 7
+  0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F,     // 8 9 : ; < = > ?
+  0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,     // @ A B C D E F G
+  0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F,     // H I J K L M N O
+  0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57,     // P Q R S T U V W
+  0x58, 0x59, 0x5A, 0x5B,                             // X Y Z [
+  0xE9,       // 5C: 233 'é' "Latin small letter E with acute"
+  0x5D,                                               //           ]
+  0xED,       // 5E: 237 'í' "Latin small letter I with acute"
+  0xF3,       // 5F: 243 'ó' "Latin small letter O with acute"
+  0xFA,       // 60: 250 'ú' "Latin small letter U with acute"
+  0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,           //   a b c d e f g
+  0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F,     // h i j k l m n o
+  0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,     // p q r s t u v w
+  0x78, 0x79, 0x7A,                                   // x y z
+  0xE7,       // 7B: 231 'ç' "Latin small letter C with cedilla"
+  0xF7,       // 7C: 247 '÷' "Division sign"
+  0xD1,       // 7D: 209 'Ñ' "Latin capital letter N with tilde"
+  0xF1,       // 7E: 241 'ñ' "Latin small letter N with tilde"
+  0x25A0      // 7F:         "Black Square" (NB: 2588 = Full Block)
+];
+
+// Special North American 608 CC char set.
+const SPECIAL_CHARACTER_SET = [
+  0xAE,    // 30: 174 '®' "Registered Sign" - registered trademark symbol
+  0xB0,    // 31: 176 '°' "Degree Sign"
+  0xBD,    // 32: 189 '½' "Vulgar Fraction One Half" (1/2 symbol)
+  0xBF,    // 33: 191 '¿' "Inverted Question Mark"
+  0x2122,  // 34:         "Trade Mark Sign" (tm superscript)
+  0xA2,    // 35: 162 '¢' "Cent Sign"
+  0xA3,    // 36: 163 '£' "Pound Sign" - pounds sterling
+  0x266A,  // 37:         "Eighth Note" - music note
+  0xE0,    // 38: 224 'à' "Latin small letter A with grave"
+  0x20,    // 39:         TRANSPARENT SPACE - for now use ordinary space
+  0xE8,    // 3A: 232 'è' "Latin small letter E with grave"
+  0xE2,    // 3B: 226 'â' "Latin small letter A with circumflex"
+  0xEA,    // 3C: 234 'ê' "Latin small letter E with circumflex"
+  0xEE,    // 3D: 238 'î' "Latin small letter I with circumflex"
+  0xF4,    // 3E: 244 'ô' "Latin small letter O with circumflex"
+  0xFB     // 3F: 251 'û' "Latin small letter U with circumflex"
+];
+
+// Extended Spanish/Miscellaneous and French char set.
+const SPECIAL_ES_FR_CHARACTER_SET = [
+  // Spanish and misc.
+  0xC1, 0xC9, 0xD3, 0xDA, 0xDC, 0xFC, 0x2018, 0xA1,
+  0x2A, 0x27, 0x2014, 0xA9, 0x2120, 0x2022, 0x201C, 0x201D,
+  // French.
+  0xC0, 0xC2, 0xC7, 0xC8, 0xCA, 0xCB, 0xEB, 0xCE,
+  0xCF, 0xEF, 0xD4, 0xD9, 0xF9, 0xDB, 0xAB, 0xBB
+];
+
+// Extended Portuguese and German/Danish char set.
+const SPECIAL_PT_DE_CHARACTER_SET = [
+  // Portuguese.
+  0xC3, 0xE3, 0xCD, 0xCC, 0xEC, 0xD2, 0xF2, 0xD5,
+  0xF5, 0x7B, 0x7D, 0x5C, 0x5E, 0x5F, 0x7C, 0x7E,
+  // German/Danish.
+  0xC4, 0xE4, 0xD6, 0xF6, 0xDF, 0xA5, 0xA4, 0x2502,
+  0xC5, 0xE5, 0xD8, 0xF8, 0x250C, 0x2510, 0x2514, 0x2518
+];
+
+const END_OF_CAPTION = 0x2F;
+
+const RESUME_CAPTION_LOADING = 0x20;
+const RESUME_DIRECT_CAPTIONING = 0x29;
+const ERASE_DISPLAYED_MEMORY = 0x2C;
+const CARRIAGE_RETURN = 0x2D;
+const ERASE_NON_DISPLAYED_MEMORY = 0x2E;
+
+const BACKSPACE = 0x21;
+
+const MID_ROW_CHAN_1 = 0x11;
+const MID_ROW_CHAN_2 = 0x19;
+
+const MISC_CHAN_1 = 0x14;
+const MISC_CHAN_2 = 0x1C;
+
+const TAB_OFFSET_CHAN_1 = 0x17;
+const TAB_OFFSET_CHAN_2 = 0x1F;
+
 class CEA708Interpreter {
 
-  constructor() {
+  constructor(options) {
+    options = options || {};
+
+    // We need to cap max caption display time in case endTime is not yet
+    // determined and the user seeks beyond the end caption control code, and
+    // we'd otherwise end up with a caption that stays on-screen for possibly
+    // a very long time (if seeking far ahead for example)
+    this.maxDisplayTime = options.maxDisplayTime || 30;
+
+    // In some streams, captions only stay on-screen for fractions of a second.
+    // We can enforce a minimum display time:
+    this.minDisplayTime = options.minDisplayTime || false;
+
+    // When minDisplayTime is applied, we don't overlap the next caption,
+    // except if the caption is due to end X seconds after the next caption
+    // begins:
+    this.allowedOverlapTime = options.allowedOverlapTime || false;
   }
 
   attach(media) {
     this.media = media;
     this.display = [];
     this.memory = [];
+
+    if (this.media.textTracks && this.media.textTracks.length) {
+      this.textTrack = this.media.textTracks[0];
+    } else {
+      this.textTrack = this.media.addTextTrack('captions', 'English', 'en');
+    }
   }
 
-  detach()
-  {
+  detach() {
     this.clear();
+    this.display = [];
+    this.memory = [];
+    this.textTrack = null;
+    this.media = null;
   }
 
-  destroy() {
-  }
-
-  _createCue()
-  {
+  createCue() {
     var VTTCue = window.VTTCue || window.TextTrackCue;
 
     var cue = this.cue = new VTTCue(-1, -1, '');
@@ -39,343 +147,226 @@ class CEA708Interpreter {
     this.memory.push(cue);
   }
 
-  clear()
-  {
-    var textTrack = this._textTrack;
-    if (textTrack && textTrack.cues)
-    {
-      while (textTrack.cues.length > 0)
-      {
-        textTrack.removeCue(textTrack.cues[0]);
+  clear() {
+    if (this.textTrack && this.textTrack.cues) {
+      while (this.textTrack.cues.length) {
+        this.textTrack.removeCue(this.textTrack.cues[0]);
       }
     }
   }
 
-  push(timestamp, bytes)
-  {
-    if (!this.cue)
-    {
-      this._createCue();
-    }
+  push(timestamp, bytes) {
+    this.timestamp = timestamp;
 
-    var count = bytes[0] & 31;
-    var position = 2;
-    var tmpByte, ccbyte1, ccbyte2, ccValid, ccType;
+    let ccCount = bytes[0] & 0x1F;
+    let position = 2;
 
-    for (var j=0; j<count; j++)
-    {
-      tmpByte = bytes[position++];
-      ccbyte1 = 0x7F & bytes[position++];
-      ccbyte2 = 0x7F & bytes[position++];
-      ccValid = ((4 & tmpByte) === 0 ? false : true);
-      ccType = (3 & tmpByte);
+    for (let i = 0; i < ccCount; i++) {
+      let tmpByte = bytes[position++];
 
-      if (ccbyte1 === 0 && ccbyte2 === 0)
-      {
+      let ccValid = ((4 & tmpByte) === 0 ? false : true);
+      if (!ccValid) {
         continue;
       }
 
-      if (ccValid)
-      {
-        if (ccType === 0) // || ccType === 1
-        {
-          // Standard Characters
-          if (0x20 & ccbyte1 || 0x40 & ccbyte1)
-          {
-            this.cue.text += this._fromCharCode(ccbyte1) + this._fromCharCode(ccbyte2);
-          }
-          // Special Characters
-          else if ((ccbyte1 === 0x11 || ccbyte1 === 0x19) && ccbyte2 >= 0x30 && ccbyte2 <= 0x3F)
-          {
-            // extended chars, e.g. musical note, accents
-            switch (ccbyte2)
-            {
-              case 48:
-                this.cue.text += '®';
-                break;
-              case 49:
-                this.cue.text += '°';
-                break;
-              case 50:
-                this.cue.text += '½';
-                break;
-              case 51:
-                this.cue.text += '¿';
-                break;
-              case 52:
-                this.cue.text += '™';
-                break;
-              case 53:
-                this.cue.text += '¢';
-                break;
-              case 54:
-                this.cue.text += '';
-                break;
-              case 55:
-                this.cue.text += '£';
-                break;
-              case 56:
-                this.cue.text += '♪';
-                break;
-              case 57:
-                this.cue.text += ' ';
-                break;
-              case 58:
-                this.cue.text += 'è';
-                break;
-              case 59:
-                this.cue.text += 'â';
-                break;
-              case 60:
-                this.cue.text += 'ê';
-                break;
-              case 61:
-                this.cue.text += 'î';
-                break;
-              case 62:
-                this.cue.text += 'ô';
-                break;
-              case 63:
-                this.cue.text += 'û';
-                break;
-            }
-          }
-          if ((ccbyte1 === 0x11 || ccbyte1 === 0x19) && ccbyte2 >= 0x20 && ccbyte2 <= 0x2F)
-          {
-            // Mid-row codes: color/underline
-            switch (ccbyte2)
-            {
-              case 0x20:
-                // White
-                break;
-              case 0x21:
-                // White Underline
-                break;
-              case 0x22:
-                // Green
-                break;
-              case 0x23:
-                // Green Underline
-                break;
-              case 0x24:
-                // Blue
-                break;
-              case 0x25:
-                // Blue Underline
-                break;
-              case 0x26:
-                // Cyan
-                break;
-              case 0x27:
-                // Cyan Underline
-                break;
-              case 0x28:
-                // Red
-                break;
-              case 0x29:
-                // Red Underline
-                break;
-              case 0x2A:
-                // Yellow
-                break;
-              case 0x2B:
-                // Yellow Underline
-                break;
-              case 0x2C:
-                // Magenta
-                break;
-              case 0x2D:
-                // Magenta Underline
-                break;
-              case 0x2E:
-                // Italics
-                break;
-              case 0x2F:
-                // Italics Underline
-                break;
-            }
-          }
-          if ((ccbyte1 === 0x14 || ccbyte1 === 0x1C) && ccbyte2 >= 0x20 && ccbyte2 <= 0x2F)
-          {
-            // Mid-row codes: color/underline
-            switch (ccbyte2)
-            {
-              case 0x20:
-                // TODO: shouldn't affect roll-ups...
-                this._clearActiveCues(timestamp);
-                // RCL: Resume Caption Loading
-                // begin pop on
-                break;
-              case 0x21:
-                // BS: Backspace
-                this.cue.text = this.cue.text.substr(0, this.cue.text.length-1);
-                break;
-              case 0x22:
-                // AOF: reserved (formerly alarm off)
-                break;
-              case 0x23:
-                // AON: reserved (formerly alarm on)
-                break;
-              case 0x24:
-                // DER: Delete to end of row
-                break;
-              case 0x25:
-                // RU2: roll-up 2 rows
-                //this._rollup(2);
-                break;
-              case 0x26:
-                // RU3: roll-up 3 rows
-                //this._rollup(3);
-                break;
-              case 0x27:
-                // RU4: roll-up 4 rows
-                //this._rollup(4);
-                break;
-              case 0x28:
-                // FON: Flash on
-                break;
-              case 0x29:
-                // RDC: Resume direct captioning
-                this._clearActiveCues(timestamp);
-                break;
-              case 0x2A:
-                // TR: Text Restart
-                break;
-              case 0x2B:
-                // RTD: Resume Text Display
-                break;
-              case 0x2C:
-                // EDM: Erase Displayed Memory
-                this._clearActiveCues(timestamp);
-                break;
-              case 0x2D:
-                // CR: Carriage Return
-                // only affects roll-up
-                //this._rollup(1);
-                break;
-              case 0x2E:
-                // ENM: Erase non-displayed memory
-                this._text = '';
-                break;
-              case 0x2F:
-                this._flipMemory(timestamp);
-                // EOC: End of caption
-                // hide any displayed captions and show any hidden one
-                break;
-            }
-          }
-          if ((ccbyte1 === 0x17 || ccbyte1 === 0x1F) && ccbyte2 >= 0x21 && ccbyte2 <= 0x23)
-          {
-            // Mid-row codes: color/underline
-            switch (ccbyte2)
-            {
-              case 0x21:
-                // TO1: tab offset 1 column
-                break;
-              case 0x22:
-                // TO1: tab offset 2 column
-                break;
-              case 0x23:
-                // TO1: tab offset 3 column
-                break;
-            }
-          }
-          else {
-            // Probably a pre-amble address code
-          }
-        }
+      let ccType = (3 & tmpByte);
+      if (ccType !== 0) {
+        continue;
+      }
+
+      let ccData1 = 0x7F & bytes[position++];
+      let ccData2 = 0x7F & bytes[position++];
+
+      // Ignore empty captions.
+      if (ccData1 === 0 && ccData2 === 0) {
+        continue;
+      }
+
+      // Special North American character set.
+      // ccData2 - P|0|1|1|X|X|X|X
+      if ((ccData1 === 0x11 || ccData1 === 0x19) && ((ccData2 & 0x70) === 0x30)) {
+        this.pushChar(this.getSpecialChar(ccData2));
+        continue;
+      }
+
+      // Extended Spanish/Miscellaneous and French character set.
+      // ccData2 - P|0|1|X|X|X|X|X
+      if ((ccData1 === 0x12 || ccData1 === 0x1A) && ((ccData2 & 0x60) === 0x20)) {
+        this.pushBackspace(); // Remove standard equivalent of the special extended char.
+        this.pushChar(this.getExtendedEsFrChar(ccData2));
+        continue;
+      }
+
+      // Extended Portuguese and German/Danish character set.
+      // ccData2 - P|0|1|X|X|X|X|X
+      if ((ccData1 === 0x13 || ccData1 === 0x1B) && ((ccData2 & 0x60) === 0x20)) {
+        this.pushBackspace(); // Remove standard equivalent of the special extended char.
+        this.pushChar(this.getExtendedPtDeChar(ccData2));
+        continue;
+      }
+
+      // Control character.
+      if (ccData1 < 0x20) {
+        this.pushCtrl(ccData1, ccData2);
+        continue;
+      }
+
+      // Basic North American character set.
+      this.pushChar(this.getChar(ccData1));
+      if (ccData2 >= 0x20) {
+        this.pushChar(this.getChar(ccData2));
       }
     }
   }
 
-  _fromCharCode(tmpByte)
-  {
-    switch (tmpByte)
-    {
-      case 42:
-        return 'á';
+  getChar(ccData) {
+    let index = (ccData & 0x7F) - 0x20;
+    return String.fromCharCode(BASIC_CHARACTER_SET[index]);
+  }
 
-      case 2:
-        return 'á';
+  getSpecialChar(ccData) {
+    let index = ccData & 0xF;
+    return String.fromCharCode(SPECIAL_CHARACTER_SET[index]);
+  }
 
-      case 2:
-        return 'é';
+  getExtendedEsFrChar(ccData) {
+    let index = ccData & 0x1F;
+    return String.fromCharCode(SPECIAL_ES_FR_CHARACTER_SET[index]);
+  }
 
-      case 4:
-        return 'í';
+  getExtendedPtDeChar(ccData) {
+    let index = ccData & 0x1F;
+    return String.fromCharCode(SPECIAL_PT_DE_CHARACTER_SET[index]);
+  }
 
-      case 5:
-        return 'ó';
+  pushBackspace() {
+    this.pushCtrl(0x14, BACKSPACE);
+  }
 
-      case 6:
-        return 'ú';
+  pushChar(char) {
+    this.ensureCue();
 
-      case 3:
-        return 'ç';
+    if ((this.cue.text === '' || this.cue.text.substr(-1) === '\n') && /\s/.test(char)) {
+      return;
+    }
 
-      case 4:
-        return '÷';
+    this.cue.text += char;
+  }
 
-      case 5:
-        return 'Ñ';
+  pushCtrl(ccData1, ccData2) {
+    this.ensureCue();
 
-      case 6:
-        return 'ñ';
-
-      case 7:
-        return '█';
-
-      default:
-        return String.fromCharCode(tmpByte);
+    if (this.isMiscCode(ccData1, ccData2)) {
+      switch (ccData2) {
+        case RESUME_CAPTION_LOADING:
+          this.clearActiveCues();
+          break;
+        case BACKSPACE:
+          this.cue.text = this.cue.text.slice(0, -1);
+          break;
+        case RESUME_DIRECT_CAPTIONING:
+          this.clearActiveCues();
+          break;
+        case ERASE_DISPLAYED_MEMORY:
+        case ERASE_NON_DISPLAYED_MEMORY:
+          this.clearActiveCues();
+          break;
+        case END_OF_CAPTION:
+          if (this.cue.text !== '') {
+            this.flipMemory();
+          }
+          break;
+        case CARRIAGE_RETURN:
+          this.maybeAppendNewline();
+          break;
+      }
+    } else if (this.isPreambleAddressCode(ccData1, ccData2)) {
+      this.maybeAppendNewline();
     }
   }
 
-  _flipMemory(timestamp)
-  {
-    this._clearActiveCues(timestamp);
-    this._flushCaptions(timestamp);
-  }
-
-  _flushCaptions(timestamp)
-  {
-    if (!this._has708)
-    {
-      this._textTrack = this.media.addTextTrack('captions', 'English', 'en');
-      this._has708 = true;
+  ensureCue() {
+    if (!this.cue) {
+      this.createCue();
     }
 
-    for(let memoryItem of this.memory)
-    {
-      memoryItem.startTime = timestamp;
-      this._textTrack.addCue(memoryItem);
+    if (!this.cue.text || typeof this.cue.text !== 'string') {
+      this.cue.text = '';
+    }
+  }
+
+  maybeAppendNewline() {
+    if (this.cue.text.length > 0 && this.cue.text.substr(-1) !== '\n') {
+      this.cue.text += '\n';
+    }
+  }
+
+  isMidRowCode(cc1, cc2) {
+    return (cc1 === MID_ROW_CHAN_1 || cc1 === MID_ROW_CHAN_2) && (cc2 >= 0x20 && cc2 <= 0x2F);
+  }
+
+  isMiscCode(cc1, cc2) {
+    return (cc1 === MISC_CHAN_1 || cc1 === MISC_CHAN_2) && (cc2 >= 0x20 && cc2 <= 0x2F);
+  }
+
+  isTabOffsetCode(cc1, cc2) {
+    return (cc1 === TAB_OFFSET_CHAN_1 || cc1 === TAB_OFFSET_CHAN_2) && (cc2 >= 0x21 && cc2 <= 0x23);
+  }
+
+  isPreambleAddressCode(cc1, cc2) {
+    return (cc1 >= 0x10 && cc1 <= 0x1F) && (cc2 >= 0x40 && cc2 <= 0x7F);
+  }
+
+  flipMemory() {
+    this.clearActiveCues();
+    this.flushCaptions();
+  }
+
+  flushCaptions() {
+    for (let memoryItem of this.memory) {
+      memoryItem.startTime = this.timestamp;
+      this.textTrack.addCue(memoryItem);
       this.display.push(memoryItem);
     }
 
     this.memory = [];
     this.cue = null;
+
+    this.adjustCueTimingValues();
   }
 
-  _clearActiveCues(timestamp)
-  {
-    for (let displayItem of this.display)
-    {
-      displayItem.endTime = timestamp;
+  adjustCueTimingValues() {
+    for (let i = 0; i < this.textTrack.cues.length; i++) {
+      let cue = this.textTrack.cues[i];
+      let nextCue = i < this.textTrack.cues.length - 1 ? this.textTrack.cues[i + 1] : null;
+      let diff = cue.endTime - cue.startTime;
+
+      if (this.minDisplayTime > 0) {
+        if (diff < this.minDisplayTime) {
+          cue.endTime = cue.startTime + this.minDisplayTime;
+        }
+      }
+
+      if (this.allowedOverlapTime > 0) {
+        if (nextCue && nextCue.startTime < cue.endTime && (cue.endTime - nextCue.startTime > this.allowedOverlapTime)) {
+          cue.endTime = nextCue.startTime - 0.001;
+        }
+      }
+    }
+  }
+
+  clearActiveCues() {
+    for (let displayItem of this.display) {
+      displayItem.endTime = this.timestamp;
+
+      if (displayItem.startTime !== Number.MAX_VALUE && displayItem.endTime - displayItem.startTime > this.maxDisplayTime) {
+        displayItem.endTime = displayItem.startTime + this.maxDisplayTime;
+      }
     }
 
     this.display = [];
   }
 
-/*  _rollUp(n)
-  {
-    // TODO: implement roll-up captions
-  }
-*/
-  _clearBufferedCues()
-  {
-    //remove them all...
-  }
-
 }
 
 export default CEA708Interpreter;
-


### PR DESCRIPTION
- Renamed the config value to enable CEA708 so that I could add sibling config properties that look similar
- Added some safeguards in timeline-controller where the CEA708 instance is being used -- if CEA708 is disabled, it looked like we'd hit some errors
- Refactored much of the CEA708Interpreter but kept the general idea behind it the same (i.e. `flipMemory` etc)
- Used character tables and the same logic for char/ctrl codes as exoplayer (*IMPORTANT* I'm unsure how to give proper credit re licensing etc). This fixes issues with line breaks and incorrect character codes being displayed
- Did some basic sanitisation of text before it gets added to the cue (trimming spaces etc)
- Added min caption display time options for some streams who hide captions too fast (along with overlap time allowance)
- Added max caption display time in case seeking throws off a caption endTime calculation

I may have forgotten some little things -- let me know if you have any questions