### PR TITLE
Fixed conversion from and to "undefined" string in index.html

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -213,7 +213,7 @@ $(document).ready(function() {
    $('#autoRecoverError').prop( "checked", autoRecoverError );
    $('#enableWorker').prop( "checked", enableWorker );
    $('#levelCapping').val(levelCapping);
-   $('#defaultAudioCodec').val(defaultAudioCodec);
+   $('#defaultAudioCodec').val(defaultAudioCodec || "undefined");
 });
 
 
@@ -937,7 +937,7 @@ function timeRangesToString(r) {
     for (var i = 0; i < sURLVariables.length; i++) {
       var sParameterName = sURLVariables[i].split('=');
       if (sParameterName[0] == sParam) {
-        return sParameterName[1];
+        return "undefined" == sParameterName[1] ? undefined : sParameterName[1];
       }
     }
     return defaultValue;


### PR DESCRIPTION
Permalinks for the demo page contain the key-value pair ```defaultAudioCodec=undefined``` by default.
When accessing such a permalink, the page interprets it as a string ```"undefined"```, which is not handled properly by [stream-controller.js](https://github.com/dailymotion/hls.js/blob/d2fc84782d50f5bcd4a772b863a4786f817f3f06/src/controller/stream-controller.js#L814)
This change converts the explicit value ```"undefined"``` from and to ```undefined``` in the demo page — I think this is preferable to an empty string but that could work as well.