### PR TITLE
Fix: remove src attr after media detaching (fixes #273)

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -63,6 +63,7 @@ class BufferController extends EventHandler {
       ms.removeEventListener('sourceclose', this.onmsc);
       // unlink MediaSource from video tag
       this.media.src = '';
+      this.media.removeAttribute('src');
       this.mediaSource = null;
       this.media = null;
       this.pendingTracks = null;


### PR DESCRIPTION
When detaching media, `media.src` set to empty string. It doesn't help, because `media.src` evaluates to `location.href` if it's empty string. To fix it, `src` attribute needs to be removed.

I didn't remove `this.media.src = ''` line, I just added `this.media.removeAttribute('src')`
Tell me if you think that `src = ''` should be removed and I will update PR

Issue: https://github.com/dailymotion/hls.js/issues/273