### PR TITLE
mentioned another video.js integration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ hls.js is (being) integrated in the following players:
  - [Clappr] (https://github.com/clappr/clappr), integrated since [0.2.14](https://github.com/clappr/clappr/releases)
  - [Flowplayer] (https://www.flowplayer.org)  through [flowplayer-hlsjs] (https://github.com/flowplayer/flowplayer-hlsjs)
  - [Videojs] (http://videojs.com) through [Videojs-hlsjs] (https://github.com/benjipott/videojs-hlsjs)
- - [Videojs] (http://videojs.com) through [videojs-hls.js] (https://github.com/streamroot/videojs-hls.js). hls.js is integrated as a SourtceHandler -- new feature in Video.js 5.
+ - [Videojs] (http://videojs.com) through [videojs-hls.js] (https://github.com/streamroot/videojs-hls.js). hls.js is integrated as a SourceHandler -- new feature in Video.js 5.
 
  it might also be integrated in the following players if you push for it !
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ hls.js is (being) integrated in the following players:
  - [Clappr] (https://github.com/clappr/clappr), integrated since [0.2.14](https://github.com/clappr/clappr/releases)
  - [Flowplayer] (https://www.flowplayer.org)  through [flowplayer-hlsjs] (https://github.com/flowplayer/flowplayer-hlsjs)
  - [Videojs] (http://videojs.com) through [Videojs-hlsjs] (https://github.com/benjipott/videojs-hlsjs)
+ - [Videojs] (http://videojs.com) through [videojs-hls.js] (https://github.com/streamroot/videojs-hls.js). hls.js is integrated as a SourtceHandler -- new feature in Video.js 5.
 
  it might also be integrated in the following players if you push for it !
 


### PR DESCRIPTION
We've integrated hls.js into Video.js v5 using Source Handler -- new interface suggested by Video.js for easy integration of media engines, so it might be a good mention in README.md.