### PR TITLE
Undefined loader fix

### DIFF
--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -38,12 +38,16 @@ class FragmentLoader extends EventHandler {
   }
 
   loaderror(event) {
-    this.loader.abort();
+    if (this.loader) {
+      this.loader.abort();
+    }
     this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_ERROR, fatal: false, frag: this.frag, response: event});
   }
 
   loadtimeout() {
-    this.loader.abort();
+    if (this.loader) {
+      this.loader.abort();
+    }
     this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_TIMEOUT, fatal: false, frag: this.frag});
   }
 

--- a/src/loader/key-loader.js
+++ b/src/loader/key-loader.js
@@ -49,12 +49,16 @@ class KeyLoader extends EventHandler {
   }
 
   loaderror(event) {
-    this.loader.abort();
+    if (this.loader) {
+      this.loader.abort();
+    }
     this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.KEY_LOAD_ERROR, fatal: false, frag: this.frag, response: event});
   }
 
   loadtimeout() {
-    this.loader.abort();
+    if (this.loader) {
+      this.loader.abort();
+    }
     this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.KEY_LOAD_TIMEOUT, fatal: false, frag: this.frag});
   }
 

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -265,7 +265,9 @@ class PlaylistLoader extends EventHandler {
       details = ErrorDetails.LEVEL_LOAD_ERROR;
       fatal = false;
     }
-    this.loader.abort();
+    if (this.loader) {
+      this.loader.abort();
+    }
     this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: this.url, loader: this.loader, response: event.currentTarget, level: this.id, id: this.id2});
   }
 
@@ -278,8 +280,10 @@ class PlaylistLoader extends EventHandler {
       details = ErrorDetails.LEVEL_LOAD_TIMEOUT;
       fatal = false;
     }
-   this.loader.abort();
-   this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: this.url, loader: this.loader, level: this.id, id: this.id2});
+    if (this.loader) {
+      this.loader.abort();
+    }
+    this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: details, fatal: fatal, url: this.url, loader: this.loader, level: this.id, id: this.id2});
   }
 }
 


### PR DESCRIPTION
Make sure we don't try to access a destroyed loader.

If a `loaderror` occurs after `this.loader` has already been set to `null` by `destroy()`, then a `TypeError` exception will be thrown upon encountering `this.loader.abort()`. This PR fixes that by checking to see if `this.loader` is defined.