### PR TITLE
Implement alternative params to liveSyncDurationCount and liveMaxLatencyDurationCount

### DIFF
--- a/API.md
+++ b/API.md
@@ -295,6 +295,23 @@ if set to 10, the player will seek back to ```liveSyncDurationCount``` whenever 
 If set, this value must be stricly superior to ```liveSyncDurationCount```
 a value too close from ```liveSyncDurationCount``` is likely to cause playback stalls.
 
+#### ```liveSyncDuration```
+(default undefined)
+
+Alternative parameter to ```liveSyncDurationCount```, expressed in seconds vs number of segments.
+If defined in the configuration object, ```liveSyncDuration``` will take precedence over the default```liveSyncDurationCount```.
+You can't define this parameter and either ```liveSyncDurationCount``` or ```liveMaxLatencyDurationCount``` in your configuration object at the same time.
+A value too low (inferior to ~3 segment durations) is likely to cause playback stalls.
+
+#### ```liveMaxLatencyDuration```
+(default undefined)
+
+Alternative parameter to ```liveMaxLatencyDurationCount```, expressed in seconds vs number of segments.
+If defined in the configuration object, ```liveMaxLatencyDuration``` will take precedence over the default```liveMaxLatencyDurationCount```.
+If set, this value must be stricly superior to ```liveSyncDuration``` which must be defined as well.
+You can't define this parameter and either ```liveSyncDurationCount``` or ```liveMaxLatencyDurationCount``` in your configuration object at the same time.
+A value too close from ```liveSyncDuration``` is likely to cause playback stalls.
+
 #### ```enableWorker```
 (default true)
 

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -196,8 +196,11 @@ class StreamController extends EventHandler {
           if (levelDetails.live) {
             // check if requested position is within seekable boundaries :
             //logger.log(`start/pos/bufEnd/seeking:${start.toFixed(3)}/${pos.toFixed(3)}/${bufferEnd.toFixed(3)}/${this.media.seeking}`);
-            if (bufferEnd < Math.max(start,end-config.liveMaxLatencyDurationCount*levelDetails.targetduration)) {
-                this.seekAfterBuffered = start + Math.max(0, levelDetails.totalduration - config.liveSyncDurationCount * levelDetails.targetduration);
+            let maxLatency = config.liveMaxLatencyDuration !== undefined ? config.liveMaxLatencyDuration : config.liveMaxLatencyDurationCount*levelDetails.targetduration;
+
+            if (bufferEnd < Math.max(start, end - maxLatency)) {
+                let targetLatency = config.liveSyncDuration !== undefined ? config.liveSyncDuration : config.liveSyncDurationCount * levelDetails.targetduration;
+                this.seekAfterBuffered = start + Math.max(0, levelDetails.totalduration - targetLatency);
                 logger.log(`buffer end: ${bufferEnd} is located too far from the end of live sliding playlist, media position will be reseted to: ${this.seekAfterBuffered.toFixed(3)}`);
                 bufferEnd = this.seekAfterBuffered;
             }
@@ -773,7 +776,8 @@ class StreamController extends EventHandler {
     if (this.startFragRequested === false) {
       // if live playlist, set start position to be fragment N-this.config.liveSyncDurationCount (usually 3)
       if (newDetails.live) {
-        this.startPosition = Math.max(0, sliding + duration - this.config.liveSyncDurationCount * newDetails.targetduration);
+        let targetLatency = this.config.liveSyncDuration !== undefined ? this.config.liveSyncDuration : this.config.liveSyncDurationCount * newDetails.targetduration;
+        this.startPosition = Math.max(0, sliding + duration - targetLatency);
       }
       this.nextLoadPosition = this.startPosition;
     }

--- a/src/hls.js
+++ b/src/hls.js
@@ -47,6 +47,8 @@ class Hls {
           maxSeekHole: 2,
           liveSyncDurationCount:3,
           liveMaxLatencyDurationCount: Infinity,
+          liveSyncDuration: undefined,
+          liveMaxLatencyDuration: undefined,
           maxMaxBufferLength: 600,
           enableWorker: true,
           enableSoftwareAES: true,
@@ -84,6 +86,11 @@ class Hls {
 
   constructor(config = {}) {
     var defaultConfig = Hls.DefaultConfig;
+
+    if ((config.liveSyncDurationCount || config.liveMaxLatencyDurationCount) && (config.liveSyncDuration || config.liveMaxLatencyDuration)) {
+      throw new Error('Illegal hls.js config: don\'t mix up liveSyncDurationCount/liveMaxLatencyDurationCount and liveSyncDuration/liveMaxLatencyDuration');
+    }
+
     for (var prop in defaultConfig) {
         if (prop in config) { continue; }
         config[prop] = defaultConfig[prop];
@@ -91,6 +98,10 @@ class Hls {
 
     if (config.liveMaxLatencyDurationCount !== undefined && config.liveMaxLatencyDurationCount <= config.liveSyncDurationCount) {
       throw new Error('Illegal hls.js config: "liveMaxLatencyDurationCount" must be gt "liveSyncDurationCount"');
+    }
+
+    if (config.liveMaxLatencyDuration !== undefined && config.liveMaxLatencyDuration <= config.liveSyncDuration) {
+      throw new Error('Illegal hls.js config: "liveMaxLatencyDuration" must be gt "liveSyncDuration"');
     }
 
     enableLogs(config.debug);

--- a/src/hls.js
+++ b/src/hls.js
@@ -100,7 +100,7 @@ class Hls {
       throw new Error('Illegal hls.js config: "liveMaxLatencyDurationCount" must be gt "liveSyncDurationCount"');
     }
 
-    if (config.liveMaxLatencyDuration !== undefined && config.liveMaxLatencyDuration <= config.liveSyncDuration) {
+    if (config.liveMaxLatencyDuration !== undefined && (config.liveMaxLatencyDuration <= config.liveSyncDuration || config.liveSyncDuration === undefined)) {
       throw new Error('Illegal hls.js config: "liveMaxLatencyDuration" must be gt "liveSyncDuration"');
     }
 


### PR DESCRIPTION
The current way of configuring the target latency is problematic with playlists with variable segment durations, because there's no way to set a consistent latency across playlist: a playlist with 10s segments will have a latency of 30s in hls.js, where the latency will only be 9s if the segments are 3s long.


This PR doesn't aim at replacing the current parameters, but to provide alternate configuration parameters expressed in seconds.

The default still are `liveSyncDurationCount` and `liveMaxLatencyDurationCount`, and those parameters can still be configured.

If set, the new parameters take precedence. 

There's a fail fast if the users tries to mix both type of parameters at initialization.

There's also a fail fast if `liveMaxLatencyDuration` is set but `liveSyncDuration` isn't: there could be weird behaviours if `liveMaxLatencyDuration <= liveSyncDurationCount * EXT-X-TARGETDURATION`

