### PR TITLE
Add XMLHttpRequestProgressEvent event in FRAG_LOAD_PROGRESS data

### DIFF
--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -53,7 +53,7 @@ class FragmentLoader extends EventHandler {
 
   loadprogress(event, stats) {
     this.frag.loaded = stats.loaded;
-    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: this.frag, stats: stats});
+    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: this.frag, stats: stats, event: event});
   }
 }
 


### PR DESCRIPTION
The XMLHttpRequestProgressEvent is very usefull to know the progress of fragment loading

If the player is in buffering state, it allow to display a percentage of loading