### PR TITLE
Small fix for data-uri support

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -224,7 +224,8 @@ class PlaylistLoader extends EventHandler {
         hls = this.hls,
         levels;
     // responseURL not supported on some browsers (it is used to detect URL redirection)
-    if (url === undefined) {
+    // data-uri mode also not supported (but no need to detect redirection)
+    if (url === undefined || url.indexOf("data:") === 0) {
       // fallback to initial URL
       url = this.url;
     }

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -225,7 +225,7 @@ class PlaylistLoader extends EventHandler {
         levels;
     // responseURL not supported on some browsers (it is used to detect URL redirection)
     // data-uri mode also not supported (but no need to detect redirection)
-    if (url === undefined || url.indexOf("data:") === 0) {
+    if (url === undefined || url.indexOf('data:') === 0) {
       // fallback to initial URL
       url = this.url;
     }


### PR DESCRIPTION
Fixes support for data-uri encoded playlists.
The only problem was about redirect detection that (in case of data uri) thinks url is "data:application/x-mpegURL," (behavior of xmlhttprequest and responseURL in case of data-uri).
Currently only tested on firefox + chrome without base64 encoding for data-uri.