### PR TITLE
Obtain level.bitrate from AVERAGE-BANDWIDTH if present (#334)

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -75,7 +75,7 @@ class PlaylistLoader extends EventHandler {
         level.width = resolution.width;
         level.height = resolution.height;
       }
-      level.bitrate = attrs.decimalInteger('BANDWIDTH');
+      level.bitrate = attrs.decimalInteger('AVERAGE-BANDWIDTH') || attrs.decimalInteger('BANDWIDTH');
       level.name = attrs.NAME;
 
       var codecs = attrs.CODECS;


### PR DESCRIPTION
The current ABR algorithm seems to treat BANDWIDTH like the average bit
rate of the stream. While this is not according to spec which demands
the peak bit rate
https://tools.ietf.org/html/draft-pantos-http-live-streaming-18#section-4.3.4.2
it's probably a realistic assumption for most streams.

To avoid punishing standard compliant streams honor the optional
AVERAGE-BANDWIDTH if present.