### PR TITLE
xhr-loader: do not set byteRange with 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ as of today, it is supported on:
  * IE11+ for Windows 8.1
  * Safari for Mac 8+ (beta)
 
+## CORS
+
+All HLS resources must be delivered with [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) permitting `GET` requests.
+
 ## Features
 
   - VoD & Live playlists

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.5.17",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "description": "Media Source Extension - HLS library, by/for Dailymotion",
   "homepage": "https://github.com/dailymotion/hls.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hls.js",
-  "version": "0.5.17",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "description": "Media Source Extension - HLS library, by/for Dailymotion",
   "homepage": "https://github.com/dailymotion/hls.js",

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -224,7 +224,8 @@ class PlaylistLoader extends EventHandler {
         hls = this.hls,
         levels;
     // responseURL not supported on some browsers (it is used to detect URL redirection)
-    if (url === undefined) {
+    // data-uri mode also not supported (but no need to detect redirection)
+    if (url === undefined || url.indexOf("data:") === 0) {
       // fallback to initial URL
       url = this.url;
     }

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -225,7 +225,7 @@ class PlaylistLoader extends EventHandler {
         levels;
     // responseURL not supported on some browsers (it is used to detect URL redirection)
     // data-uri mode also not supported (but no need to detect redirection)
-    if (url === undefined || url.indexOf("data:") === 0) {
+    if (url === undefined || url.indexOf('data:') === 0) {
       // fallback to initial URL
       url = this.url;
     }

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -132,135 +132,126 @@ class MP4Remuxer {
   }
 
   remuxVideo(track, timeOffset, contiguous) {
-    var view,
-        offset = 8,
+    var offset = 8,
         pesTimeScale = this.PES_TIMESCALE,
         pes2mp4ScaleFactor = this.PES2MP4SCALEFACTOR,
-        avcSample,
-        mp4Sample,
-        mp4SampleLength,
-        unit,
+        mp4SampleDuration,
         mdat, moof,
-        firstPTS, firstDTS, lastDTS,
-        pts, dts, ptsnorm, dtsnorm,
-        flags,
-        samples = [];
+        firstPTS, firstDTS,
+        lastPTS, lastDTS,
+        inputSamples = track.samples,
+        outputSamples = [];
+
+  // PTS is coded on 33bits, and can loop from -2^32 to 2^32
+  // PTSNormalize will make PTS/DTS value monotonic, we use last known DTS value as reference value
+   let nextAvcDts;
+    if (contiguous) {
+      // if parsed fragment is contiguous with last one, let's use last DTS value as reference
+      nextAvcDts = this.nextAvcDts;
+    } else {
+      // if not contiguous, let's use target timeOffset
+      nextAvcDts = timeOffset*pesTimeScale;
+    }
+
+    // compute first DTS and last DTS, normalize them against reference value
+    let sample = inputSamples[0];
+    firstDTS =  Math.max(this._PTSNormalize(sample.dts,nextAvcDts) - this._initDTS,0);
+    firstPTS =  Math.max(this._PTSNormalize(sample.pts,nextAvcDts) - this._initDTS,0);
+
+    // check timestamp continuity accross consecutive fragments (this is to remove inter-fragment gap/hole)
+    let delta = Math.round((firstDTS - nextAvcDts) / 90);
+    // if fragment are contiguous, or delta less than 600ms, ensure there is no overlap/hole between fragments
+    if (contiguous || Math.abs(delta) < 600) {
+      if (delta) {
+        if (delta > 1) {
+          logger.log(`AVC:${delta} ms hole between fragments detected,filling it`);
+        } else if (delta < -1) {
+          logger.log(`AVC:${(-delta)} ms overlapping between fragments detected`);
+        }
+        // remove hole/gap : set DTS to next expected DTS
+        firstDTS = inputSamples[0].dts = nextAvcDts;
+        // offset PTS as well, ensure that PTS is smaller or equal than new DTS
+        firstPTS = inputSamples[0].pts = Math.max(firstPTS - delta, nextAvcDts);
+        logger.log(`Video/PTS/DTS adjusted: ${firstPTS}/${firstDTS},delta:${delta}`);
+      }
+    }
+
+    // sample duration (as expected by trun MP4 boxes), should be the delta between sample DTS
+    // let's signal the same sample duration for all samples
+    // set this constant duration as being the avg delta between consecutive DTS.
+    sample = inputSamples[inputSamples.length-1];
+    lastDTS = Math.max(this._PTSNormalize(sample.dts,nextAvcDts) - this._initDTS,0);
+    mp4SampleDuration = Math.round((lastDTS-firstDTS)/(pes2mp4ScaleFactor*(inputSamples.length-1)));
+
+    // normalize all PTS/DTS now ...
+    for (let i = 0; i < inputSamples.length; i++) {
+      let sample = inputSamples[i];
+      // sample DTS is computed using a constant decoding offset (mp4SampleDuration) between samples
+      sample.dts = firstDTS + i*pes2mp4ScaleFactor*mp4SampleDuration;
+      // we normalize PTS against nextAvcDts, we also substract initDTS (some streams don't start @ PTS O)
+      // and we ensure that computed value is greater or equal than sample DTS
+      sample.pts = Math.max(this._PTSNormalize(sample.pts,nextAvcDts) - this._initDTS, sample.dts);
+    }
+    lastPTS = inputSamples[inputSamples.length-1].pts;
+
     /* concatenate the video data and construct the mdat in place
       (need 8 more bytes to fill length and mpdat type) */
     mdat = new Uint8Array(track.len + (4 * track.nbNalu) + 8);
-    view = new DataView(mdat.buffer);
+    let view = new DataView(mdat.buffer);
     view.setUint32(0, mdat.byteLength);
     mdat.set(MP4.types.mdat, 4);
-    while (track.samples.length) {
-      avcSample = track.samples.shift();
-      mp4SampleLength = 0;
+    while (inputSamples.length) {
+      let avcSample = inputSamples.shift(),
+          mp4SampleLength = 0;
       // convert NALU bitstream to MP4 format (prepend NALU with size field)
       while (avcSample.units.units.length) {
-        unit = avcSample.units.units.shift();
+        let unit = avcSample.units.units.shift();
         view.setUint32(offset, unit.data.byteLength);
         offset += 4;
         mdat.set(unit.data, offset);
         offset += unit.data.byteLength;
         mp4SampleLength += 4 + unit.data.byteLength;
       }
-      pts = avcSample.pts - this._initDTS;
-      dts = avcSample.dts - this._initDTS;
-      // ensure DTS is not bigger than PTS
-      dts = Math.min(pts,dts);
-      //logger.log(`Video/PTS/DTS:${Math.round(pts/90)}/${Math.round(dts/90)}`);
-      // if not first AVC sample of video track, normalize PTS/DTS with previous sample value
-      // and ensure that sample duration is positive
-      if (lastDTS !== undefined) {
-        ptsnorm = this._PTSNormalize(pts, lastDTS);
-        dtsnorm = this._PTSNormalize(dts, lastDTS);
-        var sampleDuration = (dtsnorm - lastDTS) / pes2mp4ScaleFactor;
-        if (sampleDuration <= 0) {
-          logger.log(`invalid sample duration at PTS/DTS: ${avcSample.pts}/${avcSample.dts}:${sampleDuration}`);
-          sampleDuration = 1;
-        }
-        mp4Sample.duration = sampleDuration;
-      } else {
-        let nextAvcDts, delta;
-        if (contiguous) {
-          nextAvcDts = this.nextAvcDts;
-        } else {
-          nextAvcDts = timeOffset*pesTimeScale;
-        }
-        // first AVC sample of video track, normalize PTS/DTS
-        ptsnorm = this._PTSNormalize(pts, nextAvcDts);
-        dtsnorm = this._PTSNormalize(dts, nextAvcDts);
-        delta = Math.round((dtsnorm - nextAvcDts) / 90);
-        // if fragment are contiguous, or delta less than 600ms, ensure there is no overlap/hole between fragments
-        if (contiguous || Math.abs(delta) < 600) {
-          if (delta) {
-            if (delta > 1) {
-              logger.log(`AVC:${delta} ms hole between fragments detected,filling it`);
-            } else if (delta < -1) {
-              logger.log(`AVC:${(-delta)} ms overlapping between fragments detected`);
-            }
-            // set DTS to next DTS
-            dtsnorm = nextAvcDts;
-            // offset PTS as well, ensure that PTS is smaller or equal than new DTS
-            ptsnorm = Math.max(ptsnorm - delta, dtsnorm);
-            logger.log(`Video/PTS/DTS adjusted: ${ptsnorm}/${dtsnorm},delta:${delta}`);
-          }
-        }
-        // remember first PTS of our avcSamples, ensure value is positive
-        firstPTS = Math.max(0, ptsnorm);
-        firstDTS = Math.max(0, dtsnorm);
-      }
       //console.log('PTS/DTS/initDTS/normPTS/normDTS/relative PTS : ${avcSample.pts}/${avcSample.dts}/${this._initDTS}/${ptsnorm}/${dtsnorm}/${(avcSample.pts/4294967296).toFixed(3)}');
-      mp4Sample = {
+      outputSamples.push({
         size: mp4SampleLength,
-        duration: 0,
-        cts: (ptsnorm - dtsnorm) / pes2mp4ScaleFactor,
+         // constant duration
+        duration: mp4SampleDuration,
+        // set composition time offset as a multiple of sample duration
+        cts: Math.max(0,mp4SampleDuration*Math.round((avcSample.pts - avcSample.dts)/(pes2mp4ScaleFactor*mp4SampleDuration))),
         flags: {
           isLeading: 0,
           isDependedOn: 0,
           hasRedundancy: 0,
-          degradPrio: 0
+          degradPrio: 0,
+          dependsOn : avcSample.key ? 2 : 1,
+          isNonSync : avcSample.key ? 0 : 1
         }
-      };
-      flags = mp4Sample.flags;
-      if (avcSample.key === true) {
-        // the current sample is a key frame
-        flags.dependsOn = 2;
-        flags.isNonSync = 0;
-      } else {
-        flags.dependsOn = 1;
-        flags.isNonSync = 1;
-      }
-      samples.push(mp4Sample);
-      lastDTS = dtsnorm;
-    }
-    var lastSampleDuration = 0;
-    if (samples.length >= 2) {
-      lastSampleDuration = samples[samples.length - 2].duration;
-      mp4Sample.duration = lastSampleDuration;
+      });
     }
     // next AVC sample DTS should be equal to last sample DTS + last sample duration
-    this.nextAvcDts = dtsnorm + lastSampleDuration * pes2mp4ScaleFactor;
+    this.nextAvcDts = lastDTS + mp4SampleDuration;
     track.len = 0;
     track.nbNalu = 0;
-    if(samples.length && navigator.userAgent.toLowerCase().indexOf('chrome') > -1) {
-      flags = samples[0].flags;
+    if(outputSamples.length && navigator.userAgent.toLowerCase().indexOf('chrome') > -1) {
+      let flags = outputSamples[0].flags;
     // chrome workaround, mark first sample as being a Random Access Point to avoid sourcebuffer append issue
     // https://code.google.com/p/chromium/issues/detail?id=229412
       flags.dependsOn = 2;
       flags.isNonSync = 0;
     }
-    track.samples = samples;
+    track.samples = outputSamples;
     moof = MP4.moof(track.sequenceNumber++, firstDTS / pes2mp4ScaleFactor, track);
     track.samples = [];
     this.observer.trigger(Event.FRAG_PARSING_DATA, {
       data1: moof,
       data2: mdat,
       startPTS: firstPTS / pesTimeScale,
-      endPTS: (ptsnorm + pes2mp4ScaleFactor * lastSampleDuration) / pesTimeScale,
+      endPTS: (lastPTS + pes2mp4ScaleFactor * mp4SampleDuration) / pesTimeScale,
       startDTS: firstDTS / pesTimeScale,
       endDTS: this.nextAvcDts / pesTimeScale,
       type: 'video',
-      nb: samples.length
+      nb: outputSamples.length
     });
   }
 
@@ -299,7 +290,7 @@ class MP4Remuxer {
         mp4Sample.duration = (dtsnorm - lastDTS) / pes2mp4ScaleFactor;
         if(Math.abs(mp4Sample.duration - expectedSampleDuration) > expectedSampleDuration/10) {
           // more than 10% diff between sample duration and expectedSampleDuration .... lets log that
-          logger.log(`invalid AAC sample duration at PTS ${Math.round(pts/90)},should be 1024,found :${Math.round(mp4Sample.duration*track.audiosamplerate/track.timescale)}`);
+          logger.trace(`invalid AAC sample duration at PTS ${Math.round(pts/90)},should be 1024,found :${Math.round(mp4Sample.duration*track.audiosamplerate/track.timescale)}`);
         }
         // always adjust sample duration to avoid av sync issue
         mp4Sample.duration = expectedSampleDuration;

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -229,8 +229,8 @@ class MP4Remuxer {
         }
       });
     }
-    // next AVC sample DTS should be equal to last sample DTS + last sample duration
-    this.nextAvcDts = lastDTS + mp4SampleDuration;
+    // next AVC sample DTS should be equal to last sample DTS + last sample duration (in PES timescale)
+    this.nextAvcDts = lastDTS + mp4SampleDuration*pes2mp4ScaleFactor;
     track.len = 0;
     track.nbNalu = 0;
     if(outputSamples.length && navigator.userAgent.toLowerCase().indexOf('chrome') > -1) {

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -31,7 +31,7 @@ class XhrLoader {
 
   load(url, responseType, onSuccess, onError, onTimeout, timeout, maxRetry, retryDelay, onProgress = null, frag = null) {
     this.url = url;
-    if (frag && !isNaN(frag.byteRangeStartOffset) && !isNaN(frag.byteRangeEndOffset)) {
+    if (frag && !isNaN(frag.byteRangeStartOffset) && !isNaN(frag.byteRangeEndOffset) && frag.byteRangeStartOffset !== frag.byteRangeEndOffset-1) {
         this.byteRange = frag.byteRangeStartOffset + '-' + (frag.byteRangeEndOffset-1);
     }
     this.responseType = responseType;


### PR DESCRIPTION
we had a problem, where the Request header was set with an invalid byteRange like: `Range: 543421-543421`,  where the range length was 0

this is a small fix for this problem