### PR TITLE
change event to data.response due to Reference Error on Firefox.

### DIFF
--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -225,7 +225,7 @@ class LevelController extends EventHandler {
           }
           // redispatch same error but with fatal set to true
           data.fatal = true;
-          hls.trigger(event, data);
+          hls.trigger(data.response, data);
         }
       }
     }


### PR DESCRIPTION
Change event variable to data.response when raised keyload error.