### PR TITLE
Add ProgressEvent.total to stats object 

### DIFF
--- a/src/loader/fragment-loader.js
+++ b/src/loader/fragment-loader.js
@@ -51,9 +51,9 @@ class FragmentLoader extends EventHandler {
     this.hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.FRAG_LOAD_TIMEOUT, fatal: false, frag: this.frag});
   }
 
-  loadprogress(event, stats) {
+  loadprogress(stats) {
     this.frag.loaded = stats.loaded;
-    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: this.frag, stats: stats, event: event});
+    this.hls.trigger(Event.FRAG_LOAD_PROGRESS, {frag: this.frag, stats: stats});
   }
 }
 

--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -112,8 +112,11 @@ class XhrLoader {
       stats.tfirst = performance.now();
     }
     stats.loaded = event.loaded;
+    if (event.lengthComputable) {
+      stats.total = event.total;
+    }
     if (this.onProgress) {
-      this.onProgress(event, stats);
+      this.onProgress(stats);
     }
   }
 }


### PR DESCRIPTION
and keep XHRProgressEvent encapsulated inside xhr-loader

After discussion in PR #320

If event.lengthComputable is false, then the total property on the stats object will be undefined. Is that ok? I guess this is only going to happen if the media server doesn't send back a Content-Length header, which seems highly unlikely to me, especially for video content.

By the way, couldn't this total property be used instead of [expectedLen](https://github.com/dailymotion/hls.js/blob/401ab8c6e0eb37c05b00aa3fbad08ae1bc492f54/src/controller/abr-controller.js#L63) when available?