### PR TITLE
Controller timer fixes

### DIFF
--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -30,7 +30,9 @@ class AbrController extends EventHandler {
   }
 
   onFragLoading(data) {
-    this.timer = setInterval(this.onCheck, 100);
+    if (!this.timer) {
+      this.timer = setInterval(this.onCheck, 100);
+    }
     this.fragCurrent = data.frag;
   }
 

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -20,7 +20,8 @@ class LevelController extends EventHandler {
 
   destroy() {
     if (this.timer) {
-     clearInterval(this.timer);
+      clearInterval(this.timer);
+      this.timer = null;
     }
     this._manualLevel = -1;
   }


### PR DESCRIPTION
abr-controller: Don't create extra timers. This is notably possible during fast successive seeking where `FRAG_LOADING` will occur repeatedly.
level-controller: Make sure to nullify the timer in `destroy()`.