### PR TITLE
use defaultAudioCodec as first option

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -755,7 +755,7 @@ class StreamController extends EventHandler {
             start = fragCurrent.start,
             level = fragCurrent.level,
             sn = fragCurrent.sn,
-            audioCodec = currentLevel.audioCodec || this.config.defaultAudioCodec;
+            audioCodec = this.config.defaultAudioCodec || currentLevel.audioCodec;
         if(this.audioCodecSwap) {
           logger.log('swapping playlist audio codec');
           if(audioCodec === undefined) {


### PR DESCRIPTION
Incase the manifest has a wrong codec, the default one will never be used.
When someone is already using this option its highly likely that he know what he's doing and want to set the codec to this config option