### PR TITLE
URL parser now handles base urls which don't contain a domain (for v0.5.x)

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,5 +1,4 @@
 var URLHelper = {
-
   // build an absolute URL from a relative one using the provided baseURL
   // if relativeURL is an absolute URL it will be returned as is.
   buildAbsoluteURL: function(baseURL, relativeURL) {
@@ -33,20 +32,29 @@ var URLHelper = {
       baseURL = baseURLQuerySplit[1];
     }
 
-    var baseURLDomainSplit = /^((([a-z]+):)?\/\/[a-z0-9\.\-_~]+(:[0-9]+)?\/)(.*)$/i.exec(baseURL);
-    var baseURLProtocol = baseURLDomainSplit[3];
-    var baseURLDomain = baseURLDomainSplit[1];
-    var baseURLPath = baseURLDomainSplit[5];
+    var baseURLDomainSplit = /^(([a-z]+:)?\/\/[a-z0-9\.\-_~]+(:[0-9]+)?)?(\/.*)$/i.exec(baseURL);
+    if (!baseURLDomainSplit) {
+      throw new Error('Error trying to parse base URL.');
+    }
+    
+    // e.g. 'http:', 'https:', ''
+    var baseURLProtocol = baseURLDomainSplit[2] || '';
+    // e.g. 'http://example.com', '//example.com', ''
+    var baseURLProtocolDomain = baseURLDomainSplit[1] || '';
+    // e.g. '/a/b/c/playlist.m3u8'
+    var baseURLPath = baseURLDomainSplit[4];
 
     var builtURL = null;
     if (/^\/\//.test(relativeURL)) {
-      builtURL = baseURLProtocol+'://'+URLHelper.buildAbsolutePath('', relativeURL.substring(2));
+      // relative url starts wth '//' so copy protocol (which may be '' if baseUrl didn't provide one)
+      builtURL = baseURLProtocol+'//'+URLHelper.buildAbsolutePath('', relativeURL.substring(2));
     }
     else if (/^\//.test(relativeURL)) {
-      builtURL = baseURLDomain+URLHelper.buildAbsolutePath('', relativeURL.substring(1));
+      // relative url starts with '/' so start from root of domain
+      builtURL = baseURLProtocolDomain+'/'+URLHelper.buildAbsolutePath('', relativeURL.substring(1));
     }
     else {
-      builtURL = URLHelper.buildAbsolutePath(baseURLDomain+baseURLPath, relativeURL);
+      builtURL = URLHelper.buildAbsolutePath(baseURLProtocolDomain+baseURLPath, relativeURL);
     }
 
     // put the query and hash parts back

--- a/tests/unit/utils/url.js
+++ b/tests/unit/utils/url.js
@@ -47,6 +47,17 @@ describe('utils', function() {
 
       e(fn("https://a-b.something.com/b/cd/e.m3u8?test=1#something", "//example.com/subdir/pointless/../z.ts?abc=1#test"), "https://example.com/subdir/z.ts?abc=1#test");
 
+      e(fn("//a.com/b/cd/e.m3u8", "https://example.com/z.ts"), "https://example.com/z.ts");
+      e(fn("//a.com/b/cd/e.m3u8", "g:h"), "g:h");
+      e(fn("//a.com/b/cd/e.m3u8", "https://example.com:8080/z.ts"), "https://example.com:8080/z.ts");
+      e(fn("//a.com/b/cd/e.m3u8", "z.ts"), "//a.com/b/cd/z.ts");
+      e(fn("//a.com/b/cd/e.m3u8", "../../z.ts"), "//a.com/z.ts");
+
+      e(fn("/a/b/cd/e.m3u8", "https://example.com/z.ts"), "https://example.com/z.ts");
+      e(fn("/a/b/cd/e.m3u8", "g:h"), "g:h");
+      e(fn("/a/b/cd/e.m3u8", "https://example.com:8080/z.ts"), "https://example.com:8080/z.ts");
+      e(fn("/a/b/cd/e.m3u8", "z.ts"), "/a/b/cd/z.ts");
+      e(fn("/a/b/cd/e.m3u8", "../../../z.ts"), "/z.ts");
     });
   });
 });


### PR DESCRIPTION
And also the case where the base url doesn't contain a protocol.

Fixes #424 