### PR TITLE
Improve state transitions

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -47,6 +47,7 @@ class BufferController extends EventHandler {
   }
 
   onMediaDetaching() {
+    logger.log('media source detaching');
     var ms = this.mediaSource;
     if (ms) {
       if (ms.readyState === 'open') {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -178,7 +178,8 @@ class StreamController extends EventHandler {
 
   // Ironically the "idle" state is the on we do the most logic in it seems ....
   doTickIdle() {
-    var pos, level, levelDetails, hls = this.hls, config = hls.config;
+    let pos, level, levelDetails;
+    const hls = this.hls, config = hls.config;
     // if video not attached AND
     // start fragment already requested OR start frag prefetch disable
     // exit loop
@@ -187,6 +188,7 @@ class StreamController extends EventHandler {
       (this.startFragRequested || !config.startFragPrefetch)) {
       return true;
     }
+
     // determine next candidate fragment to be loaded, based on current position and
     //  end of buffer position
     //  ensure 60s of buffer upfront
@@ -196,6 +198,7 @@ class StreamController extends EventHandler {
     } else {
       pos = this.nextLoadPosition;
     }
+
     // determine next load level
     if (this.startFragRequested === false) {
       level = this.startLevel;
@@ -203,184 +206,203 @@ class StreamController extends EventHandler {
       // we are not at playback start, get next load level from level Controller
       level = hls.nextLoadLevel;
     }
-    var bufferInfo = BufferHelper.bufferInfo(this.media,pos,config.maxBufferHole),
-        bufferLen = bufferInfo.len,
-        bufferEnd = bufferInfo.end,
-        fragPrevious = this.fragPrevious,
-        maxBufLen;
+
+    const bufferInfo = BufferHelper.bufferInfo(this.media, pos, config.maxBufferHole),
+          bufferLen = bufferInfo.len;
+
     // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
+    let maxBufLen;
     if ((this.levels[level]).hasOwnProperty('bitrate')) {
       maxBufLen = Math.max(8 * config.maxBufferSize / this.levels[level].bitrate, config.maxBufferLength);
       maxBufLen = Math.min(maxBufLen, config.maxMaxBufferLength);
     } else {
       maxBufLen = config.maxBufferLength;
     }
-    // if buffer length is less than maxBufLen try to load a new fragment
-    if (bufferLen < maxBufLen) {
-      // set next load level : this will trigger a playlist load if needed
-      hls.nextLoadLevel = level;
-      this.level = level;
-      levelDetails = this.levels[level].details;
-      // if level info not retrieved yet, switch state and wait for level retrieval
-      // if live playlist, ensure that new playlist has been refreshed to avoid loading/try to load
-      // a useless and outdated fragment (that might even introduce load error if it is already out of the live playlist)
-      if (typeof levelDetails === 'undefined' || levelDetails.live && this.levelLastLoaded !== level) {
-        this.updateState(State.WAITING_LEVEL);
+
+    // Stay idle if we are still with buffer margins
+    if (bufferLen >= maxBufLen) {
+      return true;
+    }
+
+    // if buffer length is less than maxBufLen try to load a new fragment ...
+    logger.log(`buffer length of ${bufferLen.toFixed(3)} is below max of ${maxBufLen.toFixed(3)}. checking for more payload ...`);
+
+    // set next load level : this will trigger a playlist load if needed
+    hls.nextLoadLevel = level;
+    this.level = level;
+    levelDetails = this.levels[level].details;
+
+    // if level info not retrieved yet, switch state and wait for level retrieval
+    // if live playlist, ensure that new playlist has been refreshed to avoid loading/try to load
+    // a useless and outdated fragment (that might even introduce load error if it is already out of the live playlist)
+    if (typeof levelDetails === 'undefined' || levelDetails.live && this.levelLastLoaded !== level) {
+      this.updateState(State.WAITING_LEVEL);
+      return true;
+    }
+
+    // if we have the levelDetails for the selected variant, lets continue enrichen our stream (load keys/fragments or trigger EOS, etc..)
+    return this._fetchPayloadOrEos(pos, bufferInfo, levelDetails);
+  }
+
+  _fetchPayloadOrEos(pos, bufferInfo, levelDetails) {
+    const hls = this.hls,
+          config = hls.config,
+          fragPrevious = this.fragPrevious,
+          level = this.level;
+
+    // find fragment index, contiguous with end of buffer position
+    let fragments = levelDetails.fragments,
+        fragLen = fragments.length,
+        start = fragments[0].start,
+        end = fragments[fragLen-1].start + fragments[fragLen-1].duration,
+        bufferEnd = bufferInfo.end,
+        frag;
+
+      // in case of live playlist we need to ensure that requested position is not located before playlist start
+    if (levelDetails.live) {
+      // check if requested position is within seekable boundaries :
+      //logger.log(`start/pos/bufEnd/seeking:${start.toFixed(3)}/${pos.toFixed(3)}/${bufferEnd.toFixed(3)}/${this.media.seeking}`);
+      let maxLatency = config.liveMaxLatencyDuration !== undefined ? config.liveMaxLatencyDuration : config.liveMaxLatencyDurationCount*levelDetails.targetduration;
+
+      if (bufferEnd < Math.max(start, end - maxLatency)) {
+          let targetLatency = config.liveSyncDuration !== undefined ? config.liveSyncDuration : config.liveSyncDurationCount * levelDetails.targetduration;
+          this.seekAfterBuffered = start + Math.max(0, levelDetails.totalduration - targetLatency);
+          logger.log(`buffer end: ${bufferEnd} is located too far from the end of live sliding playlist, media position will be reseted to: ${this.seekAfterBuffered.toFixed(3)}`);
+          bufferEnd = this.seekAfterBuffered;
+      }
+
+      // if end of buffer greater than live edge, don't load any fragment
+      // this could happen if live playlist intermittently slides in the past.
+      // level 1 loaded [182580161,182580167]
+      // level 1 loaded [182580162,182580169]
+      // Loading 182580168 of [182580162 ,182580169],level 1 ..
+      // Loading 182580169 of [182580162 ,182580169],level 1 ..
+      // level 1 loaded [182580162,182580168] <============= here we should have bufferEnd > end. in that case break to avoid reloading 182580168
+      // level 1 loaded [182580164,182580171]
+      //
+      if (levelDetails.PTSKnown && bufferEnd > end) {
         return true;
       }
-      // find fragment index, contiguous with end of buffer position
-      let fragments = levelDetails.fragments,
-          fragLen = fragments.length,
-          start = fragments[0].start,
-          end = fragments[fragLen-1].start + fragments[fragLen-1].duration,
-          frag;
 
-        // in case of live playlist we need to ensure that requested position is not located before playlist start
-      if (levelDetails.live) {
-        // check if requested position is within seekable boundaries :
-        //logger.log(`start/pos/bufEnd/seeking:${start.toFixed(3)}/${pos.toFixed(3)}/${bufferEnd.toFixed(3)}/${this.media.seeking}`);
-        let maxLatency = config.liveMaxLatencyDuration !== undefined ? config.liveMaxLatencyDuration : config.liveMaxLatencyDurationCount*levelDetails.targetduration;
-
-        if (bufferEnd < Math.max(start, end - maxLatency)) {
-            let targetLatency = config.liveSyncDuration !== undefined ? config.liveSyncDuration : config.liveSyncDurationCount * levelDetails.targetduration;
-            this.seekAfterBuffered = start + Math.max(0, levelDetails.totalduration - targetLatency);
-            logger.log(`buffer end: ${bufferEnd} is located too far from the end of live sliding playlist, media position will be reseted to: ${this.seekAfterBuffered.toFixed(3)}`);
-            bufferEnd = this.seekAfterBuffered;
-        }
-
-        // if end of buffer greater than live edge, don't load any fragment
-        // this could happen if live playlist intermittently slides in the past.
-        // level 1 loaded [182580161,182580167]
-        // level 1 loaded [182580162,182580169]
-        // Loading 182580168 of [182580162 ,182580169],level 1 ..
-        // Loading 182580169 of [182580162 ,182580169],level 1 ..
-        // level 1 loaded [182580162,182580168] <============= here we should have bufferEnd > end. in that case break to avoid reloading 182580168
-        // level 1 loaded [182580164,182580171]
-        //
-        if (levelDetails.PTSKnown && bufferEnd > end) {
-          return true;
-        }
-
-        if (this.startFragRequested && !levelDetails.PTSKnown) {
-          /* we are switching level on live playlist, but we don't have any PTS info for that quality level ...
-             try to load frag matching with next SN.
-             even if SN are not synchronized between playlists, loading this frag will help us
-             compute playlist sliding and find the right one after in case it was not the right consecutive one */
-          if (fragPrevious) {
-            var targetSN = fragPrevious.sn + 1;
-            if (targetSN >= levelDetails.startSN && targetSN <= levelDetails.endSN) {
-              frag = fragments[targetSN - levelDetails.startSN];
-              logger.log(`live playlist, switching playlist, load frag with next SN: ${frag.sn}`);
-            }
-          }
-          if (!frag) {
-            /* we have no idea about which fragment should be loaded.
-               so let's load mid fragment. it will help computing playlist sliding and find the right one
-            */
-            frag = fragments[Math.min(fragLen - 1, Math.round(fragLen / 2))];
-            logger.log(`live playlist, switching playlist, unknown, load middle frag : ${frag.sn}`);
+      if (this.startFragRequested && !levelDetails.PTSKnown) {
+        /* we are switching level on live playlist, but we don't have any PTS info for that quality level ...
+           try to load frag matching with next SN.
+           even if SN are not synchronized between playlists, loading this frag will help us
+           compute playlist sliding and find the right one after in case it was not the right consecutive one */
+        if (fragPrevious) {
+          var targetSN = fragPrevious.sn + 1;
+          if (targetSN >= levelDetails.startSN && targetSN <= levelDetails.endSN) {
+            frag = fragments[targetSN - levelDetails.startSN];
+            logger.log(`live playlist, switching playlist, load frag with next SN: ${frag.sn}`);
           }
         }
+        if (!frag) {
+          /* we have no idea about which fragment should be loaded.
+             so let's load mid fragment. it will help computing playlist sliding and find the right one
+          */
+          frag = fragments[Math.min(fragLen - 1, Math.round(fragLen / 2))];
+          logger.log(`live playlist, switching playlist, unknown, load middle frag : ${frag.sn}`);
+        }
+      }
+    } else {
+      // VoD playlist: if bufferEnd before start of playlist, load first fragment
+      if (bufferEnd < start) {
+        frag = fragments[0];
+      }
+    }
+    if (!frag) {
+      let foundFrag;
+      let maxFragLookUpTolerance = config.maxFragLookUpTolerance;
+      if (bufferEnd < end) {
+        if (bufferEnd > end - maxFragLookUpTolerance) {
+          maxFragLookUpTolerance = 0;
+        }
+        foundFrag = BinarySearch.search(fragments, (candidate) => {
+          // offset should be within fragment boundary - config.maxFragLookUpTolerance
+          // this is to cope with situations like
+          // bufferEnd = 9.991
+          // frag[Ø] : [0,10]
+          // frag[1] : [10,20]
+          // bufferEnd is within frag[0] range ... although what we are expecting is to return frag[1] here
+              //              frag start               frag start+duration
+              //                  |-----------------------------|
+              //              <--->                         <--->
+              //  ...--------><-----------------------------><---------....
+              // previous frag         matching fragment         next frag
+              //  return -1             return 0                 return 1
+          //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
+          if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
+            return 1;
+          }
+          else if (candidate.start - maxFragLookUpTolerance > bufferEnd) {
+            return -1;
+          }
+          return 0;
+        });
       } else {
-        // VoD playlist: if bufferEnd before start of playlist, load first fragment
-        if (bufferEnd < start) {
-          frag = fragments[0];
-        }
+        // reach end of playlist
+        foundFrag = fragments[fragLen-1];
       }
-      if (!frag) {
-        let foundFrag;
-        let maxFragLookUpTolerance = config.maxFragLookUpTolerance;
-        if (bufferEnd < end) {
-          if (bufferEnd > end - maxFragLookUpTolerance) {
-            maxFragLookUpTolerance = 0;
-          }
-          foundFrag = BinarySearch.search(fragments, (candidate) => {
-            // offset should be within fragment boundary - config.maxFragLookUpTolerance
-            // this is to cope with situations like
-            // bufferEnd = 9.991
-            // frag[Ø] : [0,10]
-            // frag[1] : [10,20]
-            // bufferEnd is within frag[0] range ... although what we are expecting is to return frag[1] here
-                //              frag start               frag start+duration
-                //                  |-----------------------------|
-                //              <--->                         <--->
-                //  ...--------><-----------------------------><---------....
-                // previous frag         matching fragment         next frag
-                //  return -1             return 0                 return 1
-            //logger.log(`level/sn/start/end/bufEnd:${level}/${candidate.sn}/${candidate.start}/${(candidate.start+candidate.duration)}/${bufferEnd}`);
-            if ((candidate.start + candidate.duration - maxFragLookUpTolerance) <= bufferEnd) {
-              return 1;
+      if (foundFrag) {
+        frag = foundFrag;
+        start = foundFrag.start;
+        //logger.log('find SN matching with pos:' +  bufferEnd + ':' + frag.sn);
+        if (fragPrevious && frag.level === fragPrevious.level && frag.sn === fragPrevious.sn) {
+          if (frag.sn < levelDetails.endSN) {
+            frag = fragments[frag.sn + 1 - levelDetails.startSN];
+            logger.log(`SN just loaded, load next one: ${frag.sn}`);
+          } else {
+            // have we reached end of VOD playlist ?
+            if (!levelDetails.live) {
+              // Finalize the media stream
+              this.hls.trigger(Event.BUFFER_EOS);
             }
-            else if (candidate.start - maxFragLookUpTolerance > bufferEnd) {
-              return -1;
+            // We might be loading the last fragment but actually the media
+            // is currently processing a seek command and waiting for new data to resume at another point.
+            // Going to ended state while media is seeking can spawn an infinite buffering broken state.
+            if (!this.media.seeking) {
+              this.updateState(State.ENDED);
             }
-            return 0;
-          });
-        } else {
-          // reach end of playlist
-          foundFrag = fragments[fragLen-1];
-        }
-        if (foundFrag) {
-          frag = foundFrag;
-          start = foundFrag.start;
-          //logger.log('find SN matching with pos:' +  bufferEnd + ':' + frag.sn);
-          if (fragPrevious && frag.level === fragPrevious.level && frag.sn === fragPrevious.sn) {
-            if (frag.sn < levelDetails.endSN) {
-              frag = fragments[frag.sn + 1 - levelDetails.startSN];
-              logger.log(`SN just loaded, load next one: ${frag.sn}`);
-            } else {
-              // have we reached end of VOD playlist ?
-              if (!levelDetails.live) {
-                // Finalize the media stream
-                this.hls.trigger(Event.BUFFER_EOS);
-              }
-              // We might be loading the last fragment but actually the media
-              // is currently processing a seek command and waiting for new data to resume at another point.
-              // Going to ended state while media is seeking can spawn an infinite buffering broken state.
-              if (!this.media.seeking) {
-                this.updateState(State.ENDED);
-              }
-              frag = null;
-            }
+            frag = null;
           }
         }
       }
-      if(frag) {
-        //logger.log('loading frag ' + i +',pos/bufEnd:' + pos.toFixed(3) + '/' + bufferEnd.toFixed(3));
-        if ((frag.decryptdata.uri != null) && (frag.decryptdata.key == null)) {
-          logger.log(`Loading key for ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}`);
-          this.updateState(State.KEY_LOADING);
-          hls.trigger(Event.KEY_LOADING, {frag: frag});
-        } else {
-          logger.log(`Loading ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}, currentTime:${pos},bufferEnd:${bufferEnd.toFixed(3)}`);
-          frag.autoLevel = hls.autoLevelEnabled;
-          if (this.levels.length > 1) {
-            frag.expectedLen = Math.round(frag.duration * this.levels[level].bitrate / 8);
-            frag.trequest = performance.now();
-          }
-          // ensure that we are not reloading the same fragments in loop ...
-          if (this.fragLoadIdx !== undefined) {
-            this.fragLoadIdx++;
-          } else {
-            this.fragLoadIdx = 0;
-          }
-          if (frag.loadCounter) {
-            frag.loadCounter++;
-            let maxThreshold = config.fragLoadingLoopThreshold;
-            // if this frag has already been loaded 3 times, and if it has been reloaded recently
-            if (frag.loadCounter > maxThreshold && (Math.abs(this.fragLoadIdx - frag.loadIdx) < maxThreshold)) {
-              hls.trigger(Event.ERROR, {type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_LOOP_LOADING_ERROR, fatal: false, frag: frag});
-              return false;
-            }
-          } else {
-            frag.loadCounter = 1;
-          }
-          frag.loadIdx = this.fragLoadIdx;
-          this.fragCurrent = frag;
-          this.startFragRequested = true;
-          hls.trigger(Event.FRAG_LOADING, {frag: frag});
-          this.updateState(State.FRAG_LOADING);
+    }
+    if(frag) {
+      //logger.log('loading frag ' + i +',pos/bufEnd:' + pos.toFixed(3) + '/' + bufferEnd.toFixed(3));
+      if ((frag.decryptdata.uri != null) && (frag.decryptdata.key == null)) {
+        logger.log(`Loading key for ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}`);
+        this.updateState(State.KEY_LOADING);
+        hls.trigger(Event.KEY_LOADING, {frag: frag});
+      } else {
+        logger.log(`Loading ${frag.sn} of [${levelDetails.startSN} ,${levelDetails.endSN}],level ${level}, currentTime:${pos},bufferEnd:${bufferEnd.toFixed(3)}`);
+        frag.autoLevel = hls.autoLevelEnabled;
+        if (this.levels.length > 1) {
+          frag.expectedLen = Math.round(frag.duration * this.levels[level].bitrate / 8);
+          frag.trequest = performance.now();
         }
+        // ensure that we are not reloading the same fragments in loop ...
+        if (this.fragLoadIdx !== undefined) {
+          this.fragLoadIdx++;
+        } else {
+          this.fragLoadIdx = 0;
+        }
+        if (frag.loadCounter) {
+          frag.loadCounter++;
+          let maxThreshold = config.fragLoadingLoopThreshold;
+          // if this frag has already been loaded 3 times, and if it has been reloaded recently
+          if (frag.loadCounter > maxThreshold && (Math.abs(this.fragLoadIdx - frag.loadIdx) < maxThreshold)) {
+            hls.trigger(Event.ERROR, {type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_LOOP_LOADING_ERROR, fatal: false, frag: frag});
+            return false;
+          }
+        } else {
+          frag.loadCounter = 1;
+        }
+        frag.loadIdx = this.fragLoadIdx;
+        this.fragCurrent = frag;
+        this.startFragRequested = true;
+        hls.trigger(Event.FRAG_LOADING, {frag: frag});
+        this.updateState(State.FRAG_LOADING);
       }
     }
   }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -290,12 +290,15 @@ class StreamController extends EventHandler {
                   frag = fragments[frag.sn + 1 - levelDetails.startSN];
                   logger.log(`SN just loaded, load next one: ${frag.sn}`);
                 } else {
+                  // have we reached end of VOD playlist ?
+                  if (!levelDetails.live) {
+                    // Finalize the media stream
+                    this.hls.trigger(Event.BUFFER_EOS);
+                  }
                   // We might be loading the last fragment but actually the media
                   // is currently processing a seek command and waiting for new data to resume at another point.
                   // Going to ended state while media is seeking can spawn an infinite buffering broken state.
-                  // have we reached end of VOD playlist ?
-                  if (!levelDetails.live && !this.media.seeking) {
-                    this.hls.trigger(Event.BUFFER_EOS);
+                  if (!this.media.seeking) {
                     this.state = State.ENDED;
                   }
                   frag = null;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -136,7 +136,7 @@ class StreamController extends EventHandler {
       case State.IDLE:
         // when this returns false there was an error and we shall return immediatly
         // from current tick
-        if (!this.doTickIdle()) {
+        if (!this._doTickIdle()) {
           return;
         }
         break;
@@ -178,9 +178,10 @@ class StreamController extends EventHandler {
   // Ironically the "idle" state is the on we do the most logic in it seems ....
   // NOTE: Maybe we could rather schedule a check for buffer length after half of the currently
   //       played segment, or on pause/play/seek instead of naively checking every 100ms?
-  doTickIdle() {
+  _doTickIdle() {
     const hls = this.hls,
           config = hls.config;
+
     // if video not attached AND
     // start fragment already requested OR start frag prefetch disable
     // exit loop
@@ -190,9 +191,6 @@ class StreamController extends EventHandler {
       return true;
     }
 
-    // determine next candidate fragment to be loaded, based on current position and
-    //  end of buffer position
-    //  ensure 60s of buffer upfront
     // if we have not yet loaded any fragment, start loading from start position
     let pos;
     if (this.loadedmetadata) {
@@ -218,6 +216,9 @@ class StreamController extends EventHandler {
     } else {
       maxBufLen = config.maxBufferLength;
     }
+
+    // determine next candidate fragment to be loaded, based on current position and end of buffer position
+    // ensure up to `config.maxMaxBufferLength` of buffer upfront
 
     const bufferInfo = BufferHelper.bufferInfo(this.media, pos, config.maxBufferHole),
           bufferLen = bufferInfo.len;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -408,6 +408,7 @@ class StreamController extends EventHandler {
         this.state = State.FRAG_LOADING;
       }
     }
+    return true;
   }
 
   set state(nextState) {

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -177,6 +177,8 @@ class StreamController extends EventHandler {
   }
 
   // Ironically the "idle" state is the on we do the most logic in it seems ....
+  // NOTE: Maybe we could rather schedule a check for buffer length after half of the currently
+  //       played segment, or on pause/play/seek instead of naively checking every 100ms?
   doTickIdle() {
     const hls = this.hls,
           config = hls.config;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -178,8 +178,8 @@ class StreamController extends EventHandler {
 
   // Ironically the "idle" state is the on we do the most logic in it seems ....
   doTickIdle() {
-    let pos, level, levelDetails;
-    const hls = this.hls, config = hls.config;
+    const hls = this.hls,
+          config = hls.config;
     // if video not attached AND
     // start fragment already requested OR start frag prefetch disable
     // exit loop
@@ -193,6 +193,7 @@ class StreamController extends EventHandler {
     //  end of buffer position
     //  ensure 60s of buffer upfront
     // if we have not yet loaded any fragment, start loading from start position
+    let pos;
     if (this.loadedmetadata) {
       pos = this.media.currentTime;
     } else {
@@ -200,15 +201,13 @@ class StreamController extends EventHandler {
     }
 
     // determine next load level
+    let level;
     if (this.startFragRequested === false) {
       level = this.startLevel;
     } else {
       // we are not at playback start, get next load level from level Controller
       level = hls.nextLoadLevel;
     }
-
-    const bufferInfo = BufferHelper.bufferInfo(this.media, pos, config.maxBufferHole),
-          bufferLen = bufferInfo.len;
 
     // compute max Buffer Length that we could get from this load level, based on level bitrate. don't buffer more than 60 MB and more than 30s
     let maxBufLen;
@@ -219,6 +218,8 @@ class StreamController extends EventHandler {
       maxBufLen = config.maxBufferLength;
     }
 
+    const bufferInfo = BufferHelper.bufferInfo(this.media, pos, config.maxBufferHole),
+          bufferLen = bufferInfo.len;
     // Stay idle if we are still with buffer margins
     if (bufferLen >= maxBufLen) {
       return true;
@@ -230,8 +231,8 @@ class StreamController extends EventHandler {
     // set next load level : this will trigger a playlist load if needed
     hls.nextLoadLevel = level;
     this.level = level;
-    levelDetails = this.levels[level].details;
 
+    const levelDetails = this.levels[level].details;
     // if level info not retrieved yet, switch state and wait for level retrieval
     // if live playlist, ensure that new playlist has been refreshed to avoid loading/try to load
     // a useless and outdated fragment (that might even introduce load error if it is already out of the live playlist)

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -290,8 +290,11 @@ class StreamController extends EventHandler {
                   frag = fragments[frag.sn + 1 - levelDetails.startSN];
                   logger.log(`SN just loaded, load next one: ${frag.sn}`);
                 } else {
+                  // We might be loading the last fragment but actually the media
+                  // is currently processing a seek command and waiting for new data to resume at another point.
+                  // Going to ended state while media is seeking can spawn an infinite buffering broken state.
                   // have we reached end of VOD playlist ?
-                  if (!levelDetails.live) {
+                  if (!levelDetails.live && !this.media.seeking) {
                     this.hls.trigger(Event.BUFFER_EOS);
                     this.state = State.ENDED;
                   }
@@ -608,6 +611,7 @@ class StreamController extends EventHandler {
   }
 
   onMediaSeeking() {
+    logger.log('media seeking to ' + this.media.currentTime);
     if (this.state === State.FRAG_LOADING) {
       // check if currently loaded fragment is inside buffer.
       //if outside, cancel fragment loading, otherwise do nothing
@@ -640,6 +644,7 @@ class StreamController extends EventHandler {
   }
 
   onMediaSeeked() {
+    logger.log('media seeked to ' + this.media.currentTime);
     // tick to speed up FRAGMENT_PLAYING triggering
     this.tick();
   }

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -118,10 +118,10 @@ class StreamController extends EventHandler {
   }
 
   doTick() {
-    var level, hls = this.hls;
     //logger.log(this.state);
     switch(this.state) {
       case State.STARTING:
+        var hls = this.hls;
         // determine load level
         this.startLevel = hls.startLevel;
         if (this.startLevel === -1) {
@@ -142,7 +142,7 @@ class StreamController extends EventHandler {
         }
         break;
       case State.WAITING_LEVEL:
-        level = this.levels[this.level];
+        var level = this.levels[this.level];
         // check if playlist is already loaded
         if (level && level.details) {
           this.updateState(State.IDLE);
@@ -389,6 +389,7 @@ class StreamController extends EventHandler {
     this.state = state;
     if (this.previousState !== this.state) {
       logger.log(`engine state transition from ${this.previousState} to ${this.state}`);
+      this.hls.trigger(State.STREAM_STATE_TRANSITION, {previousState: this.previousState, state: this.state});
     }
     this.previousState = state;
   }

--- a/src/event-handler.js
+++ b/src/event-handler.js
@@ -46,9 +46,9 @@ class EventHandler {
     }
   }
 
-  /*
-  * arguments: event (string), data (any)
-  */
+  /**
+   * arguments: event (string), data (any)
+   */
   onEvent(event, data) {
     this.onEventGeneric(event, data);
   }

--- a/src/events.js
+++ b/src/events.js
@@ -71,6 +71,6 @@ module.exports = {
   KEY_LOADING: 'hlsKeyLoading',
   // fired when a decrypt key loading is completed - data: { frag : fragment object, payload : key payload, stats : { trequest, tfirst, tload, length}}
   KEY_LOADED: 'hlsKeyLoaded',
-  // fired upon stream controller state transitions
+  // fired upon stream controller state transitions - data: {previousState, nextState}
   STREAM_STATE_TRANSITION: 'hlsStreamStateTransition'
 };

--- a/src/events.js
+++ b/src/events.js
@@ -71,4 +71,6 @@ module.exports = {
   KEY_LOADING: 'hlsKeyLoading',
   // fired when a decrypt key loading is completed - data: { frag : fragment object, payload : key payload, stats : { trequest, tfirst, tload, length}}
   KEY_LOADED: 'hlsKeyLoaded',
+  // fired upon stream controller state transitions
+  STREAM_STATE_TRANSITION: 'hlsStreamStateTransition'
 };


### PR DESCRIPTION
StreamController: Introduce updateState + destructure doTick

This allows for log lines like

```
[log] > engine state transition from FRAG_LOADING to PARSING
logger.js:47 [log] > Demuxing 44 of [0 ,161],level 0
logger.js:47 [log] > parsed audio,PTS:[234.575,244.986],DTS:[234.575/244.986],nb:488
logger.js:47 [log] > parsed video,PTS:[234.640,244.974],DTS:[234.557/244.974],nb:250
logger.js:47 [log] > engine state transition from PARSING to PARSED
logger.js:47 [log] > media buffered : [10.447333,74.056932][205.028666,244.973599][297.274,330.39031][632.143333,675.681999]
logger.js:47 [log] > engine state transition from PARSED to IDLE
```

So we can track state transitions easily and centralize transition logic if needed (or trigger events/actions on specific transitions).

Also decomposed `doTick` to improve readability and scope of this function.