### PR TITLE
Updated README.md w/ CEA-708

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,10 @@ All HLS resources must be delivered with [CORS headers](https://developer.mozill
   - [Redundant/Failover Playlists](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/UsingHTTPLiveStreaming/UsingHTTPLiveStreaming.html#//apple_ref/doc/uid/TP40008332-CH102-SW22)
   - Timed Metadata for HTTP Live Streaming (in ID3 format, carried in MPEG-2 TS)
   - AES-128 decryption (AES-128 mode)
-  - CEA-708 captions (pop-on, channel 1)
+  - CEA-708 captions
 
 ## Not Supported (Yet)
 
-  - CEA-708 captions (roll-up, paint-on, channel 2)
   - MP3 / WebVTT container
   - Alternate Audio Track Rendition (Master Playlist with alternative Audio)
 


### PR DESCRIPTION
I just noticed we never updated the README when we added full CEA-708 support. It's cleaned up here.

I deleted my fork and started over, btw, so it'd be clean. I'll learn how to rebase if i need to :)