### PR TITLE
Make the ABR controller take the playback rate into account

### DIFF
--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -67,18 +67,18 @@ class AbrController extends EventHandler {
     if (v && (!v.paused || !v.readyState) && frag.autoLevel && frag.level) {
       let requestDelay = performance.now() - frag.trequest;
       // monitor fragment load progress after half of expected fragment duration,to stabilize bitrate
-      if (requestDelay > (500 * frag.duration)) {
+      if (requestDelay > (500 * frag.duration / v.playbackRate)) {
         let loadRate = Math.max(1,frag.loaded * 1000 / requestDelay); // byte/s; at least 1 byte/s to avoid division by zero
         if (frag.expectedLen < frag.loaded) {
           frag.expectedLen = frag.loaded;
         }
         let pos = v.currentTime;
         let fragLoadedDelay = (frag.expectedLen - frag.loaded) / loadRate;
-        let bufferStarvationDelay = BufferHelper.bufferInfo(v,pos,hls.config.maxBufferHole).end - pos;
+        let bufferStarvationDelay = (BufferHelper.bufferInfo(v,pos,hls.config.maxBufferHole).end - pos) / v.playbackRate;
         // consider emergency switch down only if we have less than 2 frag buffered AND
         // time to finish loading current fragment is bigger than buffer starvation delay
         // ie if we risk buffer starvation if bw does not increase quickly
-        if (bufferStarvationDelay < 2*frag.duration && fragLoadedDelay > bufferStarvationDelay) {
+        if ((bufferStarvationDelay < (2 * frag.duration / v.playbackRate)) && (fragLoadedDelay > bufferStarvationDelay)) {
           let fragLevelNextLoadedDelay, nextLoadLevel;
           // lets iterate through lower level and try to find the biggest one that could avoid rebuffering
           // we start from current level - 1 and we step down , until we find a matching level

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -152,7 +152,11 @@ class AbrController extends EventHandler {
   }
 
   get nextAutoLevel() {
-    var lastbw = this.lastbw, hls = this.hls,adjustedbw, i, maxAutoLevel;
+    let hls = this.hls,
+        v = hls.media,
+        playbackRate = ((v && v.playbackRate !== 0) ? Math.abs(v.playbackRate) : 1.0),
+        lastbw = this.lastbw / playbackRate;
+    var adjustedbw, i, maxAutoLevel;
     if (this._autoLevelCapping === -1 && hls.levels && hls.levels.length) {
       maxAutoLevel = hls.levels.length - 1;
     } else {

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -64,9 +64,9 @@ class AbrController extends EventHandler {
     }
     /* only monitor frag retrieval time if
     (video not paused OR first fragment being loaded(ready state === HAVE_NOTHING = 0)) AND autoswitching enabled AND not lowest level (=> means that we have several levels) */
-    if (v && (!v.paused || !v.readyState) && frag.autoLevel && frag.level) {
+    if (v && ((!v.paused && (v.playbackRate !== 0)) || !v.readyState) && frag.autoLevel && frag.level) {
       let requestDelay = performance.now() - frag.trequest,
-          playbackRate = ((v.playbackRate !== 0) ? Math.abs(v.playbackRate) : 1.0);
+          playbackRate = Math.abs(v.playbackRate);
       // monitor fragment load progress after half of expected fragment duration,to stabilize bitrate
       if (requestDelay > (500 * frag.duration / playbackRate)) {
         let loadRate = Math.max(1,frag.loaded * 1000 / requestDelay); // byte/s; at least 1 byte/s to avoid division by zero


### PR DESCRIPTION
Resolves https://github.com/dailymotion/hls.js/issues/461 by using playbackRate to adjust starvation delay and next level calculations.