### PR TITLE
Use EWMA in tracking bandwidth in ABR controller

### DIFF
--- a/API.md
+++ b/API.md
@@ -474,6 +474,15 @@ whether or not to enable CEA-708 captions
 
 parameter should be a boolean
 
+#### ```abrControllerBandwidthWeight```
+(default : 1.0)
+
+The weight to apply to the current bandwidth measurement when calculating the Exponentially-Weighted Moving Average (EWMA) of the bandwidth in the ABR controller.
+
+If ```α := abrControllerBandwidthWeight```, then ```bandwidth average := (α * latest bandwidth measurement) + ((1 - α) * previous bandwidth average)```.
+
+parameter should be a float in the range (0.0, 1.0]
+
 ## Video Binding/Unbinding API
 
 #### ```hls.attachMedia(videoElement)```

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -46,10 +46,11 @@ class AbrController extends EventHandler {
     // and leading to wrong bw estimation
     if (stats.aborted === undefined && data.frag.loadCounter === 1) {
       this.lastfetchduration = (performance.now() - stats.trequest) / 1000;
+      let thisbw = (stats.loaded * 8) / this.lastfetchduration;
       if (this.lastbw) {
-        this.lastbw = this.exponentialWeighting * ((stats.loaded * 8) / this.lastfetchduration) + (1 - this.exponentialWeighting) * this.lastbw;
+        this.lastbw = this.exponentialWeighting * thisbw + (1 - this.exponentialWeighting) * this.lastbw;
       } else {
-        this.lastbw = (stats.loaded * 8) / this.lastfetchduration;
+        this.lastbw = thisbw;
       }
       //console.log(`fetchDuration:${this.lastfetchduration},bw:${(this.lastbw/1000).toFixed(0)}/${stats.aborted}`);
     }

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -22,9 +22,6 @@ class AbrController extends EventHandler {
     this._nextAutoLevel = -1;
     this.hls = hls;
     this.onCheck = this.abandonRulesCheck.bind(this);
-
-    // This factor weights the last bandwidth measurement as an exponential moving average.
-    this.exponentialWeighting = 0.8;
   }
 
   destroy() {
@@ -48,7 +45,8 @@ class AbrController extends EventHandler {
       this.lastfetchduration = (performance.now() - stats.trequest) / 1000;
       let thisbw = (stats.loaded * 8) / this.lastfetchduration;
       if (this.lastbw) {
-        this.lastbw = this.exponentialWeighting * thisbw + (1 - this.exponentialWeighting) * this.lastbw;
+        let w = this.hls.config.abrControllerBandwidthWeight;
+        this.lastbw = (w * thisbw) + (1.0 - w) * this.lastbw;
       } else {
         this.lastbw = thisbw;
       }

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -22,6 +22,9 @@ class AbrController extends EventHandler {
     this._nextAutoLevel = -1;
     this.hls = hls;
     this.onCheck = this.abandonRulesCheck.bind(this);
+
+    // This factor weights the last bandwidth measurement as an exponential moving average.
+    this.exponentialWeighting = 0.8;
   }
 
   destroy() {
@@ -43,7 +46,11 @@ class AbrController extends EventHandler {
     // and leading to wrong bw estimation
     if (stats.aborted === undefined && data.frag.loadCounter === 1) {
       this.lastfetchduration = (performance.now() - stats.trequest) / 1000;
-      this.lastbw = (stats.loaded * 8) / this.lastfetchduration;
+      if (this.lastbw) {
+        this.lastbw = this.exponentialWeighting * ((stats.loaded * 8) / this.lastfetchduration) + (1 - this.exponentialWeighting) * this.lastbw;
+      } else {
+        this.lastbw = (stats.loaded * 8) / this.lastfetchduration;
+      }
       //console.log(`fetchDuration:${this.lastfetchduration},bw:${(this.lastbw/1000).toFixed(0)}/${stats.aborted}`);
     }
   }

--- a/src/hls.js
+++ b/src/hls.js
@@ -80,7 +80,8 @@ class Hls {
           streamController: StreamController,
           timelineController: TimelineController,
           enableCEA708Captions: true,
-          enableMP2TPassThrough : false
+          enableMP2TPassThrough : false,
+          abrControllerBandwidthWeight: 1.0
         };
     }
     return Hls.defaultConfig;


### PR DESCRIPTION
Use exponential weighted moving average in keeping the last bandwidth in the ABR controller to smooth out segment load times a bit.