### PR TITLE
EwmaBandWidthEstimator undefined object fix

### DIFF
--- a/src/controller/ewma-bandwidth-estimator.js
+++ b/src/controller/ewma-bandwidth-estimator.js
@@ -38,7 +38,7 @@ class EwmaBandWidthEstimator {
 
 
   getEstimate() {
-    if (this.fast_.getTotalWeight() < this.minWeight_) {
+    if (!this.fast_ || this.fast_.getTotalWeight() < this.minWeight_) {
       return this.defaultEstimate_;
     }
     //console.log('slow estimate:'+ Math.round(this.slow_.getEstimate()));


### PR DESCRIPTION
Make sure that `this.fast_` is defined in `EwmaBandWidthEstimator.getEstimate()` before trying to access it.

Prevents errors from being thrown near the start of playback.