### PR TITLE
Adding of boolean config.forceStartToPlayFromFirstFragment (Update stream-controller.js)

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -796,7 +796,7 @@ class StreamController extends EventHandler {
     // compute start position
     if (this.startFragRequested === false) {
       // if live playlist, set start position to be fragment N-this.config.liveSyncDurationCount (usually 3)
-      if (newDetails.live) {
+      if (newDetails.live &&  !this.config.forceStartToPlayFromFirstFragment) {
         let targetLatency = this.config.liveSyncDuration !== undefined ? this.config.liveSyncDuration : this.config.liveSyncDurationCount * newDetails.targetduration;
         this.startPosition = Math.max(0, sliding + duration - targetLatency);
       }


### PR DESCRIPTION
Please, add option forceStartToPlayFromFirstFragment to hls.js config. It is really needed, when I need to play playlist once (only one playlist without future playlist updates) fully from first segment (.ts) to last segment (.ts).

Btw, I know hls.js hack: when config.liveSyncDurationCount  = 0, it is try to play from end of last segment (.ts), but switched to begin of first segment, because of playlist end. It is emulates forceStartToPlayFromFirstFragment = true, but it is ugly and sometimes brokes hls.js work.

P.S.:
I have playlist like this:

#EXTM3U
#EXT-X-PLAYLIST-TYPE:EVENT
#EXT-X-DISCONTINUITY
#EXT-X-TARGETDURATION:66
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_182814765.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_182914925.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_183015086.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:58.88,
ng_1_20160609_183115246.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.17,
ng_1_20160609_183214127.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_183314300.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_183414461.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_183514621.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_183614782.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_183714942.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_183815102.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:58.88,
ng_1_20160609_183915263.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184014143.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184114304.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184214464.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184314624.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184414785.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184514945.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184615106.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:40.48,
ng_1_20160609_184715266.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.12,
ng_1_20160609_184807000.mp4.ts
#EXT-X-DISCONTINUITY
#EXTINF:60.16,
ng_1_20160609_184907120.mp4.ts
#EXT-X-ENDLIST

And I want to play it from first segment to last segment, but I generate this playlist on the fly. So firstly I have only part of this playlist without "#EXT-X-ENDLIST". After adding of forceStartToPlayFromFirstFragment option I fixed the problem of playback big pause on ending of first playlist part by calling of hls.startLoad in case of unknown Hls.ErrorTypes.MEDIA_ERROR .