### PR TITLE
Fix for cap level to player size 

### DIFF
--- a/src/controller/cap-level-controller.js
+++ b/src/controller/cap-level-controller.js
@@ -87,7 +87,7 @@ class CapLevelController extends EventHandler {
   get mediaWidth() {
     let width;
     if (this.media) {
-      width = this.media.width || this.media.clientWidth || this.media.offsetWidth;
+      width =  this.media.clientWidth || this.media.offsetWidth;
       width *= this.contentScaleFactor;
     }
     return width;
@@ -96,7 +96,7 @@ class CapLevelController extends EventHandler {
   get mediaHeight() {
     let height;
     if (this.media) {
-      height = this.media.height || this.media.clientHeight || this.media.offsetHeight;
+      height = this.media.clientHeight || this.media.offsetHeight;
       height *= this.contentScaleFactor; 
     }
     return height;


### PR DESCRIPTION
not working when using percentage based size values on video tag
removing .width because it does not work when using % based sizing on container (returns 100 when using 100% and 90 when using 90% etc)