### PR TITLE
EwmaBandWidthEstimator undefined object fix #2

### DIFF
--- a/API.md
+++ b/API.md
@@ -477,35 +477,45 @@ parameter should be a boolean
 #### ```abrEwmaFastLive```
 (default : 5.0)
 
-Fast bitrate Exponential moving average half-life , used to compute average bitrate for Live streams
+Fast bitrate Exponential moving average half-life, used to compute average bitrate for Live streams
 Half of the estimate is based on the last abrEwmaFastLive seconds of sample history.
 Each of the sample is weighted by the fragment loading duration.
+
 parameter should be a float greater than 0
 
 #### ```abrEwmaSlowLive```
 (default : 9.0)
 
-Slow bitrate Exponential moving average half-life , used to compute average bitrate for Live streams
+Slow bitrate Exponential moving average half-life, used to compute average bitrate for Live streams
 Half of the estimate is based on the last abrEwmaSlowLive seconds of sample history.
 Each of the sample is weighted by the fragment loading duration.
-parameter should be a float greater than abrEwmaFastLive
 
+parameter should be a float greater than abrEwmaFastLive
 
 #### ```abrEwmaFastVoD```
 (default : 4.0)
 
-Fast bitrate Exponential moving average half-life , used to compute average bitrate for VoD streams 
+Fast bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams 
 Half of the estimate is based on the last abrEwmaFastVoD seconds of sample history.
 Each of the sample is weighted by the fragment loading duration.
+
 parameter should be a float greater than 0
 
 #### ```abrEwmaSlowVoD```
 (default : 15.0)
 
-Slow bitrate Exponential moving average half-life , used to compute average bitrate for VoD streams 
+Slow bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams 
 Half of the estimate is based on the last abrEwmaSlowVoD seconds of sample history.
 Each of the sample is weighted by the fragment loading duration.
+
 parameter should be a float greater than abrEwmaFastVoD
+
+#### ```abrEwmaDefaultEstimate```
+(default : 500000)
+
+Default bandwidth estimate in bits/second prior to collecting fragment bandwidth samples.
+
+parameter should be a float
 
 
 #### ```abrBandWidthFactor```

--- a/design.md
+++ b/design.md
@@ -48,7 +48,7 @@ design idea is pretty simple :
 
   - [src/controller/abr-controller.js][]
     - in charge of determining auto quality level.
-    - auto quality switch algorithm is bitrate based : fragment loading bitrate is monitored and smoothed using 2 exponential weighted moving average (a fast one, to adapt quickly on bandwidth drop and a slow one, to avoid ramping up to quickly on bandwidth increase)
+    - auto quality switch algorithm is bitrate based : fragment loading bitrate is monitored and smoothed using 2 exponential weighted moving average (a fast one, to adapt quickly on bandwidth drop and a slow one, to avoid ramping up too quickly on bandwidth increase)
     - in charge of **monitoring fragment loading speed** (by monitoring data received from FRAG_LOAD_PROGRESS event)
      - "expected time of fragment load completion" is computed using "fragment loading instant bandwidth".
      - this time is compared to the "expected time of buffer starvation".

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -50,7 +50,7 @@ class AbrController extends EventHandler {
         ewmaFast = config.abrEwmaFastVoD;
         ewmaSlow = config.abrEwmaSlowVoD;
       }
-      this.bwEstimator = new EwmaBandWidthEstimator(hls,ewmaSlow,ewmaFast);
+      this.bwEstimator = new EwmaBandWidthEstimator(hls,ewmaSlow,ewmaFast,config.abrEwmaDefaultEstimate);
     }
 
     let frag = data.frag;
@@ -184,7 +184,8 @@ class AbrController extends EventHandler {
       return Math.min(this._nextAutoLevel,maxAutoLevel);
     }
 
-    let avgbw = this.bwEstimator.getEstimate(),adjustedbw;
+    let avgbw = this.bwEstimator ? this.bwEstimator.getEstimate() : config.abrEwmaDefaultEstimate,
+        adjustedbw;
     // follow algorithm captured from stagefright :
     // https://android.googlesource.com/platform/frameworks/av/+/master/media/libstagefright/httplive/LiveSession.cpp
     // Pick the highest bandwidth stream below or equal to estimated bandwidth.

--- a/src/controller/ewma-bandwidth-estimator.js
+++ b/src/controller/ewma-bandwidth-estimator.js
@@ -11,9 +11,9 @@ import EWMA from '../utils/ewma';
 
 class EwmaBandWidthEstimator {
 
-  constructor(hls,slow,fast) {
+  constructor(hls,slow,fast,defaultEstimate) {
     this.hls = hls;
-    this.defaultEstimate_ = 5e5; // 500kbps
+    this.defaultEstimate_ = defaultEstimate;
     this.minWeight_ = 0.001;
     this.minDelayMs_ = 50;
     this.slow_ = new EWMA(slow);
@@ -32,7 +32,7 @@ class EwmaBandWidthEstimator {
 
 
   getEstimate() {
-    if (!this.fast_ || this.fast_.getTotalWeight() < this.minWeight_) {
+    if (!this.fast_ || !this.slow_ || this.fast_.getTotalWeight() < this.minWeight_) {
       return this.defaultEstimate_;
     }
     //console.log('slow estimate:'+ Math.round(this.slow_.getEstimate()));

--- a/src/hls.js
+++ b/src/hls.js
@@ -87,6 +87,7 @@ class Hls {
           abrEwmaSlowLive: 9,
           abrEwmaFastVoD: 4,
           abrEwmaSlowVoD: 15,
+          abrEwmaDefaultEstimate: 5e5, // 500 kbps
           abrBandWidthFactor : 0.8,
           abrBandWidthUpFactor : 0.7
         };


### PR DESCRIPTION
ewma-bandwidth-estimator: Make `defaultEstimate` globally-configurable so it's available before `bwEstimator` is initialized

(f9c183d66a89bb1f9c10d1244c50477c6037a98c created this undefined object issue.)

My use case is reading `nextLoadLevel` before playback has started, btw.