### PR TITLE
xhr-loader: store & clear on abort the retry timeout (race cond fix)

### DIFF
--- a/src/utils/xhr-loader.js
+++ b/src/utils/xhr-loader.js
@@ -99,14 +99,17 @@ class XhrLoader {
       this.onSuccess(event, stats, context);
     // everything else is a failure
     } else {
-      // error ...
+      // retry first
       if (stats.retry < this.maxRetry) {
         logger.warn(`${status} while loading ${this.url}, retrying in ${this.retryDelay}...`);
+        // aborts and resets internal state
         this.destroy();
+        // schedule retry
         this.retryTimeout = window.setTimeout(this.loadInternal.bind(this), this.retryDelay);
-        // exponential backoff
+        // set exponential backoff
         this.retryDelay = Math.min(2 * this.retryDelay, 64000);
         stats.retry++;
+      // permanent failure
       } else {
         logger.error(`${status} while loading ${this.url}` );
         this.onError(event, context);


### PR DESCRIPTION
... otherwise we might get aborted while having a retry scheduled. unlikely but possible.

also renamed `timeoutHandler` to `requestTimeout` to differentiate between scheduling of request-timeout and retry-timeout calls/handlers.