### PR TITLE
Allow comments after #EXTINF before URL

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -195,7 +195,7 @@ class PlaylistLoader extends EventHandler {
         byteRangeStartOffset = null,
         tagList = [];
 
-    regexp = /(?:(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.*)?)|(?:#EXT-X-(START):(.*))|(?:#EXT(INF):(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE):(\d+(?:@\d+(?:\.\d+)?))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.*))|(?:#EXT-X-(VERSION):(\d+))|(?:#(.*):(.*))|(?:#(.*)))(?:.*)\r?\n?/g;
+    regexp = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT(INF):(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE):(\d+(?:@\d+(?:\.\d+)?))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.+))|(?:#EXT-X-(VERSION):(\d+))|(?:(#)(.*):(.*))|(?:(#)(.*)))(?:.*)\r?\n?/g;
     while ((result = regexp.exec(string)) !== null) {
       result.shift();
       result = result.filter(function(n) { return (n !== undefined); });
@@ -293,8 +293,12 @@ class PlaylistLoader extends EventHandler {
           programDateTime = new Date(Date.parse(result[1]));
           tagList.push(result);
           break;
-        default:
+        case '#':
+          result.shift();
           tagList.push(result);
+          break;
+        default:
+          logger.warn(`line parsed but not handled: ${result}`);
           break;
       }
     }

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -193,7 +193,7 @@ class PlaylistLoader extends EventHandler {
         byteRangeStartOffset,
         tagList = [];
 
-    regexp = /(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.*)[\r\n]+([^#|\r\n]+)?)|(?:#EXT-X-(START):(.*))|(?:#EXT(INF):([\d\.]+)[^\r\n]*([\r\n]+[^#|\r\n]+)?)|(?:#EXT-X-(BYTERANGE):([\d]+[@[\d]*)]*[\r\n]+([^#|\r\n]+)?|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.*)[\r\n]+([^#|\r\n]+)?)|(?:#EXT-X-(VERSION):(.*))|(?:#(.*):(.*))|(?:#(.*))/g;
+    regexp = /(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.*)[\r\n]+([^#|\r\n]+)?)|(?:#EXT-X-(START):(.*))|(?:#EXT(INF):([\d\.]+)[^\r\n]*(?:(?:[\r\n]|#(?!EXT).*)+(?!#EXT)(.*))?)|(?:#EXT-X-(BYTERANGE):([\d]+[@[\d]*)]*[\r\n]+([^#|\r\n]+)?|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.*)[\r\n]+([^#|\r\n]+)?)|(?:#EXT-X-(VERSION):(\d+))|(?:#(EXT(?:.*)):(.*))|(?:#(EXT(?:.*)))/g;
     while ((result = regexp.exec(string)) !== null) {
       result.shift();
       result = result.filter(function(n) { return (n !== undefined); });

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -292,10 +292,6 @@ class PlaylistLoader extends EventHandler {
         case 'PROGRAM-DATE-TIME':
           programDateTime = new Date(Date.parse(result[1]));
           tagList.push(result);
-          if (frag && !frag.url && result.length >= 3) {
-            frag.url = this.resolve(result[2], baseurl);
-            frag.programDateTime = programDateTime;
-          }
           break;
         default:
           tagList.push(result);

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -189,11 +189,13 @@ class PlaylistLoader extends EventHandler {
         frag = null,
         result,
         regexp,
-        byteRangeEndOffset,
-        byteRangeStartOffset,
+        duration = null,
+        title = null,
+        byteRangeEndOffset = null,
+        byteRangeStartOffset = null,
         tagList = [];
 
-    regexp = /(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.*)[\r\n]+([^#|\r\n]+)?)|(?:#EXT-X-(START):(.*))|(?:#EXT(INF):([\d\.]+)[^\r\n]*(?:(?:[\r\n]|#(?!EXT).*)+(?!#EXT)(.*))?)|(?:#EXT-X-(BYTERANGE):([\d]+[@[\d]*)]*[\r\n]+([^#|\r\n]+)?|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.*)[\r\n]+([^#|\r\n]+)?)|(?:#EXT-X-(VERSION):(\d+))|(?:#(EXT(?:.*)):(.*))|(?:#(EXT(?:.*)))/g;
+    regexp = /(?:(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.*)?)|(?:#EXT-X-(START):(.*))|(?:#EXT(INF):(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE):(\d+(?:@\d+(?:\.\d+)?))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.*))|(?:#EXT-X-(VERSION):(\d+))|(?:#(.*):(.*))|(?:#(.*)))(?:.*)[\r\n]?/g;
     while ((result = regexp.exec(string)) !== null) {
       result.shift();
       result = result.filter(function(n) { return (n !== undefined); });
@@ -227,23 +229,21 @@ class PlaylistLoader extends EventHandler {
             byteRangeStartOffset = parseInt(params[1]);
           }
           byteRangeEndOffset = parseInt(params[0]) + byteRangeStartOffset;
-          if (frag && !frag.url) {
-            frag.byteRangeStartOffset = byteRangeStartOffset;
-            frag.byteRangeEndOffset = byteRangeEndOffset;
-            frag.url = this.resolve(result[2], baseurl);
-            tagList.push(result);
-          }
           break;
         case 'INF':
-          var duration = parseFloat(result[1]);
+          duration = parseFloat(result[1]);
+          title = result[2] ? result[2] : null;
+          tagList.push(result);
+          break;
+        case '': // url
           if (!isNaN(duration)) {
             var sn = currentSN++;
             fragdecryptdata = this.fragmentDecryptdataFromLevelkey(levelkey, sn);
-            var url = result[2] ? this.resolve(result[2], baseurl) : null;
-            tagList.push(result);
+            var url = result[1] ? this.resolve(result[1], baseurl) : null;
             frag = {url: url,
                     type : type,
                     duration: duration,
+                    title: title,
                     start: totalduration,
                     sn: sn,
                     level: id,
@@ -255,6 +255,8 @@ class PlaylistLoader extends EventHandler {
                     tagList: tagList};
             level.fragments.push(frag);
             totalduration += duration;
+            duration = null;
+            title = null;
             byteRangeStartOffset = null;
             programDateTime = null;
             tagList = [];
@@ -277,16 +279,6 @@ class PlaylistLoader extends EventHandler {
               // Initialization Vector (IV)
               levelkey.iv = decryptiv;
             }
-          }
-
-          //issue #425, applying url and decrypt data in instances where EXT-KEY immediately follow EXT-INF
-          if (frag && !frag.url && result.length >= 3) {
-            frag.url = this.resolve(result[2], baseurl);
-
-            //we have not moved onto another segment, we are still parsing one
-            fragdecryptdata = this.fragmentDecryptdataFromLevelkey(levelkey, currentSN - 1);
-            frag.decryptdata = fragdecryptdata;
-            tagList.push(result);
           }
           break;
         case 'START':

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -195,7 +195,7 @@ class PlaylistLoader extends EventHandler {
         byteRangeStartOffset = null,
         tagList = [];
 
-    regexp = /(?:(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.*)?)|(?:#EXT-X-(START):(.*))|(?:#EXT(INF):(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE):(\d+(?:@\d+(?:\.\d+)?))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.*))|(?:#EXT-X-(VERSION):(\d+))|(?:#(.*):(.*))|(?:#(.*)))(?:.*)[\r\n]?/g;
+    regexp = /(?:(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.*)?)|(?:#EXT-X-(START):(.*))|(?:#EXT(INF):(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE):(\d+(?:@\d+(?:\.\d+)?))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.*))|(?:#EXT-X-(VERSION):(\d+))|(?:#(.*):(.*))|(?:#(.*)))(?:.*)\r?\n?/g;
     while ((result = regexp.exec(string)) !== null) {
       result.shift();
       result = result.filter(function(n) { return (n !== undefined); });

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -216,11 +216,11 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
 #EXT-X-ALLOW-CACHE:NO
 #EXT-X-TARGETDURATION:11
 #EXT-X-KEY:METHOD=AES-128,URI="oceans.key"
-#EXTINF:11, no desc
+#EXTINF:11,no desc
 oceans_aes-audio=65000-video=236000-1.ts
-#EXTINF:7, no desc
+#EXTINF:7,no desc
 oceans_aes-audio=65000-video=236000-2.ts
-#EXTINF:7, no desc
+#EXTINF:7,no desc
 oceans_aes-audio=65000-video=236000-3.ts
 #EXT-X-ENDLIST`;
     var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://foo.com/adaptive/oceans_aes/oceans_aes.m3u8',0);
@@ -231,6 +231,7 @@ oceans_aes-audio=65000-video=236000-3.ts
     assert.strictEqual(result.fragments.length, 3);
     assert.strictEqual(result.fragments[0].cc, 0);
     assert.strictEqual(result.fragments[0].duration, 11);
+    assert.strictEqual(result.fragments[0].title, "no desc");
     assert.strictEqual(result.fragments[0].level, 0);
     assert.strictEqual(result.fragments[0].url, 'http://foo.com/adaptive/oceans_aes/oceans_aes-audio=65000-video=236000-1.ts');
     assert.strictEqual(result.fragments[0].decryptdata.uri, 'http://foo.com/adaptive/oceans_aes/oceans.key');

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -156,6 +156,7 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
 #EXTINF:11.320,
 /sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(2)/video/107/282/158282701_mp4_h264_aac_hq.ts
 #EXTINF:13.480,
+# general comment
 /sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(3)/video/107/282/158282701_mp4_h264_aac_hq.ts
 #EXTINF:11.200,
 /sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(4)/video/107/282/158282701_mp4_h264_aac_hq.ts


### PR DESCRIPTION
Fixes #555

Also restrict so that all items that go into 'tagList' in the fragment objects start with "EXT", i.e. not general comments. This is because with this change a general comment after `#EXTINF` would not make it to the `tagList` anyway.

A separate issue should the keys in `tagList` contain the EXT prefix?

I.e should the regex be
```javascript
(?:#EXT(.*):(.*))|#(EXT(.*))
```
instead of
```javascript
(?:#(EXT(?:.*)):(.*))|(?:#(EXT(?:.*)))
```

(This PR also reads the `EXT-X-VERSION` as `\d+` like v0.5.x)