### PR TITLE
Actually fill audio gaps at the beginning of a segment with empty audio.

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -66,18 +66,22 @@
     this.videoCodec = videoCodec;
     this.timeOffset = timeOffset;
     this._duration = duration;
-    this.contiguous = false;
+    this.contiguous = null;
     if (cc !== this.lastCC) {
       logger.log('discontinuity detected');
       this.insertDiscontinuity();
       this.lastCC = cc;
+      this.contiguous = false;
     }
     if (level !== this.lastLevel) {
       logger.log('level switch detected');
       this.switchLevel();
       this.lastLevel = level;
-    } else if (sn === (this.lastSN+1)) {
+      this.contiguous = false;
+    } else if ((sn === (this.lastSN+1)) && (this.contiguous === null)) {
       this.contiguous = true;
+    } else {
+      this.contiguous = false;
     }
     this.lastSN = sn;
 

--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -66,22 +66,18 @@
     this.videoCodec = videoCodec;
     this.timeOffset = timeOffset;
     this._duration = duration;
-    this.contiguous = null;
+    this.contiguous = false;
     if (cc !== this.lastCC) {
       logger.log('discontinuity detected');
       this.insertDiscontinuity();
       this.lastCC = cc;
-      this.contiguous = false;
     }
     if (level !== this.lastLevel) {
       logger.log('level switch detected');
       this.switchLevel();
       this.lastLevel = level;
-      this.contiguous = false;
-    } else if ((sn === (this.lastSN+1)) && (this.contiguous === null)) {
+    } else if (sn === (this.lastSN+1)) {
       this.contiguous = true;
-    } else {
-      this.contiguous = false;
     }
     this.lastSN = sn;
 

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -495,7 +495,7 @@ class MP4Remuxer {
           mp4Sample = {
             size: fillFrame.byteLength,
             cts: 0,
-            duration:0,
+            duration: 1024,
             flags: {
               isLeading: 0,
               isDependedOn: 0,
@@ -513,7 +513,7 @@ class MP4Remuxer {
       mp4Sample = {
         size: unit.byteLength,
         cts: 0,
-        duration:0,
+        duration: 0,
         flags: {
           isLeading: 0,
           isDependedOn: 0,

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -30,6 +30,7 @@ class MP4Remuxer {
 
   insertDiscontinuity() {
     this._initPTS = this._initDTS = undefined;
+    this.nextAacPts = this.nextAvcDts = 0;
   }
 
   switchLevel() {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -361,7 +361,8 @@ class MP4Remuxer {
         firstPTS, firstDTS, lastDTS,
         pts, dts, ptsnorm, dtsnorm,
         samples = [],
-        samples0 = [];
+        samples0 = [],
+        fillFrame, newStamp;
 
     track.samples.sort(function(a, b) {
       return (a.pts-b.pts);
@@ -396,8 +397,8 @@ class MP4Remuxer {
         var missing = Math.round(delta / pesFrameDuration);
         logger.log(`Injecting ${missing} frame${missing > 1 ? 's' : ''} of missing audio due to ${Math.round(delta / 90)} ms gap.`);
         for (var j = 0; j < missing; j++) {
-          var newStamp = samples0[i - 1].pts + pesFrameDuration,
-              fillFrame = AAC.getSilentFrame(track.channelCount);
+          newStamp = samples0[i - 1].pts + pesFrameDuration;
+          fillFrame = AAC.getSilentFrame(track.channelCount);
           if (!fillFrame) {
             logger.log('Unable to get silent frame for given audio codec; duplicating last frame instead.');
             fillFrame = sample.unit.slice(0);
@@ -437,13 +438,22 @@ class MP4Remuxer {
       } else {
         ptsnorm = this._PTSNormalize(pts, nextAacPts);
         dtsnorm = this._PTSNormalize(dts, nextAacPts);
-        let delta = Math.round(1000 * (ptsnorm - nextAacPts) / pesTimeScale);
+        let delta = Math.round(1000 * (ptsnorm - nextAacPts) / pesTimeScale),
+            numMissingFrames = 0;
         // if fragment are contiguous, detect hole/overlapping between fragments
         if (contiguous) {
           // log delta
           if (delta) {
             if (delta > 0) {
+              numMissingFrames = Math.round((ptsnorm - nextAacPts) / pesFrameDuration);
               logger.log(`${delta} ms hole between AAC samples detected,filling it`);
+              if (numMissingFrames > 0) {
+                fillFrame = AAC.getSilentFrame(track.channelCount);
+                if (!fillFrame) {
+                  fillFrame = unit.slice(0);
+                }
+                track.len += numMissingFrames * fillFrame.length;
+              }
               // if we have frame overlap, overlapping for more than half a frame duraion
             } else if (delta < -12) {
               // drop overlapping audio frames... browser will deal with it
@@ -468,6 +478,29 @@ class MP4Remuxer {
         } else {
           // no audio samples
           return;
+        }
+        for (i = 0; i < numMissingFrames; i++) {
+          newStamp = ptsnorm - (numMissingFrames - i) * pesFrameDuration;
+          fillFrame = AAC.getSilentFrame(track.channelCount);
+          if (!fillFrame) {
+            logger.log('Unable to get silent frame for given audio codec; duplicating this frame instead.');
+            fillFrame = unit.slice(0);
+          }
+          mdat.set(fillFrame, offset);
+          offset += fillFrame.byteLength;
+          mp4Sample = {
+            size: fillFrame.byteLength,
+            cts: 0,
+            duration:0,
+            flags: {
+              isLeading: 0,
+              isDependedOn: 0,
+              hasRedundancy: 0,
+              degradPrio: 0,
+              dependsOn: 1,
+            }
+          };
+          samples.push(mp4Sample);
         }
       }
       mdat.set(unit, offset);


### PR DESCRIPTION
Resolves https://github.com/dailymotion/hls.js/issues/578 by filling audio gaps at the beginning of a segment with empty audio (when possible).