### PR TITLE
stream-controller: Ignore startDTS when it is NaN in onFragLoaded

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -795,7 +795,7 @@ class StreamController extends EventHandler {
         var currentLevel = this.levels[this.level],
             details = currentLevel.details,
             duration = details.totalduration,
-            start = fragCurrent.startDTS !== undefined ? fragCurrent.startDTS  : fragCurrent.start,
+            start = fragCurrent.startDTS !== undefined && !isNaN(fragCurrent.startDTS) ? fragCurrent.startDTS  : fragCurrent.start,
             level = fragCurrent.level,
             sn = fragCurrent.sn,
             audioCodec = currentLevel.audioCodec || this.config.defaultAudioCodec;


### PR DESCRIPTION
Prevents playback failure when calling `stopLoad`/`startLoad` repeatedly on live content

Fixes regression introduced by 582aab08657b6f92feb84de1bb992de7adf0f6c3

---

While bisecting this, I created a version-changeable demo page that pulls from GitHub. It also includes a few extra `console.log` statements and a "500ms reload" button to help reproduce the problem.

Good versions:
http://gigcasters.com/test/hls.js-demo/?v=v0.5.33
http://gigcasters.com/test/hls.js-demo/?v=ef29675128650369013909318da0a48b7a2cb69f

Bad versions:
http://gigcasters.com/test/hls.js-demo/?v=0859f8012bf229aef2fdeb0186ef44bd1adbaafb
http://gigcasters.com/test/hls.js-demo/?v=v0.5.34

Fixed (local) version:
http://gigcasters.com/test/hls.js-demo/?v=v0.5.41-custom

The `dist-proxy.php` the page references is here: https://gist.github.com/nhjm449/09f9a907f5f01200caf92a7d708ba047