### PR TITLE
Fix SEI message parsing to match the h.264 spec

### DIFF
--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -404,22 +404,21 @@
           var payloadType = 0;
           var payloadSize = 0;
           var endOfCaptions = false;
+          var b = 0;
 
           while (!endOfCaptions && expGolombDecoder.bytesAvailable > 1) {
             payloadType = 0;
             do {
-                if (expGolombDecoder.bytesAvailable!==0) {
-                  payloadType += expGolombDecoder.readUByte();
-                }
-            } while (payloadType === 0xFF);
+                b = expGolombDecoder.readUByte();
+                payloadType += b;
+            } while (b === 0xFF);
 
             // Parse payload size.
             payloadSize = 0;
             do {
-                if (expGolombDecoder.bytesAvailable!==0) {
-                  payloadSize += expGolombDecoder.readUByte();
-                }
-            } while (payloadSize === 0xFF);
+                b = expGolombDecoder.readUByte();
+                payloadSize += b;
+            } while (b === 0xFF);
 
             // TODO: there can be more than one payload in an SEI packet...
             // TODO: need to read type and size in a while loop to get them all


### PR DESCRIPTION
There are some cases where the hls.js decoder enters an infinite loop during h.264 decoding, specifically when handling SEI messages. This causes playback to stall, and will completely lock up the browser tab if workers are disabled. In profiling the stall, I've discovered that the decoder can get hung up when parsing SEI payloadType at these lines:

https://github.com/dailymotion/hls.js/blob/3ddaa4c77de1d7be11ec53ef93d7ed5a4367cd40/src/demux/tsdemuxer.js#L378-L382

Presumably this could also happen during payloadSize parsing as well, but I've not experienced it first hand.

Looking at the h.264 spec, the reference implementation, and a few other notable implementations (Exoplayer and ffmpeg), it looks like the current way hls.js parses payloadType and payloadSize is incorrect. Specifically, these implementations check the last parsed byte's value rather than the payloadSize in order to terminate the loop.

Reference: http://iphome.hhi.de/suehring/tml/doc/ldec/html/sei_8c_source.html
Exoplayer: https://github.com/google/ExoPlayer/blob/master/library/src/main/java/com/google/android/exoplayer/extractor/ts/SeiReader.java#L45-L48
ffmpeg: https://github.com/FFmpeg/FFmpeg/blob/8ef57a0d6154119e1a616dd8c29e8c32e35808a0/libavcodec/hevc_sei.c#L343-L351

This patch changes hls.js to match the spec (modeled off of the exoplayer implementation), and resolves the issue. I'm not an h.264 expert by any means, and also don't understand the intention of @jlacivita's [original implementation ](https://github.com/dailymotion/hls.js/commit/3ddaa4c77de1d7be11ec53ef93d7ed5a4367cd40). I'm unclear if this is the correct fix or not, but as I mentioned, it does resolve the issue.