### PR TITLE
added attrs property to level loading event

### DIFF
--- a/API.md
+++ b/API.md
@@ -433,6 +433,7 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
      * Calling load() will start retrieving content at given URL (HTTP GET).
      *
      * @param {string} url URL to load.
+     * @param {object} context Object containing extra contextual information
      * @param {string} responseType XHR response type (arraybuffer or default response type for playlist).
      * @param {Function} onSuccess Callback triggered upon successful loading of URL.
      *                             It should return XHR event and load stats object `{ trequest, tfirst, tload }`.
@@ -442,7 +443,7 @@ Note: If `fLoader` or `pLoader` are used, they overwrite `loader`!
      * @param {number} maxRetry Max number of load retries.
      * @param {number} retryDelay Delay between an I/O error and following connection retry (ms). This to avoid spamming the server.
      */
-    this.load = function (url, responseType, onSuccess, onError, onTimeOut, timeout, maxRetry, retryDelay) {};
+    this.load = function (url, context, responseType, onSuccess, onError, onTimeOut, timeout, maxRetry, retryDelay) {};
 
     /** Abort any loading in progress. */
     this.abort = function () {};

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -139,7 +139,7 @@ class LevelController extends EventHandler {
         // level not retrieved yet, or live playlist we need to (re)load it
         logger.log(`(re)loading playlist for level ${newLevel}`);
         var urlId = level.urlId;
-        this.hls.trigger(Event.LEVEL_LOADING, {url: level.url[urlId], level: newLevel, id: urlId});
+        this.hls.trigger(Event.LEVEL_LOADING, {url: level.url[urlId], level: newLevel, id: urlId, attrs: level.attrs});
       }
     } else {
       // invalid level id given, trigger error

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -35,7 +35,7 @@ class PlaylistLoader extends EventHandler {
   }
 
   onLevelLoading(data) {
-    this.load(data.url, { type : 'level', level : data.level, id : data.id});
+    this.load(data.url, { type : 'level', level : data.level, id : data.id, attrs: data.attrs });
   }
 
   onAudioTrackLoading(data) {


### PR DESCRIPTION
I found that when I was creating a custom loader class that I wanted extra information regarding bandwidth when performing a level load. Figured instead of just only passing bandwidth through the event why not all known attributes of the level.

Also added context object to the DefaultConfig.loader API documentation.