### PR TITLE
Fixed updateMediaElementDuration sourceBuffer loop

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -279,7 +279,7 @@ class BufferController extends EventHandler {
       return;
     }
     for (let type in sourceBuffer) {
-      if (sourceBuffer[type].updating) {
+      if (sourceBuffer[type] && sourceBuffer[type].updating) {
         // can't set duration whilst a buffer is updating
         return;
       }


### PR DESCRIPTION
By using `for (let type in sourceBuffer)`, today we get "error: otherError - fatal: false - internalException" due to the fact the for loop is trying to access other attributes in sourceBuffer than the actual buffer (e.g., "onaddsourcebuffer", "length"...)