### PR TITLE
Bad Frag handling for final fragment

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -184,6 +184,15 @@ class StreamController extends EventHandler {
             this.state = State.WAITING_LEVEL;
             break;
           }
+
+          // DO NOT try to load a new fragment if we just got done loading the final fragment.
+          if (!levelDetails.live && !isSeeking && fragPrevious && fragPrevious.sn === levelDetails.endSN) {
+            // Finalize the media stream
+            this.hls.trigger(Event.BUFFER_EOS);
+            this.state = State.ENDED;
+            break;
+          }
+
           // find fragment index, contiguous with end of buffer position
           let fragments = levelDetails.fragments,
               fragLen = fragments.length,


### PR DESCRIPTION
Some media files don't necessarily have matching audio and video streams (i.e. there's a temporal disconnect between when they end).  This could cause a state where hls.js had loaded the final sn for a given level, and would continue loading more simply because the buffer didn't show as being completely full (see check on line 175 of stream-controller.js).  Add a check that fires if we're not live, not seeking, and the last fragment loaded has the same SN as the final fragment to fire EOS.