### PR TITLE
Fix for #638

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -360,17 +360,18 @@ class PlaylistLoader extends EventHandler {
         }
       } else {
         let levels = this.parseMasterPlaylist(string, url),
-             audiotracks = [];
-             // if any audio codec signalled, push main audio track in audio track list
-            if (levels[0].audioCodec) {
-              audiotracks.push({id: 0, type : 'main', name : 'main'});
-            }
-            this.parseMasterPlaylistMedia(audiotracks,string, url, 'AUDIO');
-        // multi level playlist, parse level info
-        if (levels.length) {
-          hls.trigger(Event.MANIFEST_LOADED, {levels: levels, audioTracks : audiotracks, url: url, stats: stats});
-        } else {
+            audiotracks = [];
+
+        if (!levels.length) {
           hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no level found in manifest'});
+        } else {
+          // if any audio codec signalled, push main audio track in audio track list
+          if (levels[0].audioCodec) {
+            audiotracks.push({id: 0, type: 'main', name: 'main'});
+          }
+          this.parseMasterPlaylistMedia(audiotracks,string, url, 'AUDIO');
+          // multi level playlist, parse level info
+          hls.trigger(Event.MANIFEST_LOADED, {levels: levels, audioTracks: audiotracks, url: url, stats: stats});
         }
       }
     } else {


### PR DESCRIPTION
In case when playlist doesn't contain level info, loader fails with TypeError.
To fix this issue, check level existence before using it and, if there is no levels emit correct event.