### PR TITLE
Add browserify derequire plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "private": false,
   "scripts": {
     "clean": "rimraf dist/*",
-    "prebuild": "npm run clean & npm run test",
-    "build": "npm run babel && browserify -t browserify-versionify -t [babelify] -s Hls src/index.js --debug | exorcist dist/hls.js.map -b . > dist/hls.js",
+    "prebuild": "npm run clean && npm run test",
+    "build": "npm run babel && browserify -t browserify-versionify -t [babelify] -p browserify-derequire -s Hls src/index.js --debug | exorcist dist/hls.js.map -b . > dist/hls.js",
     "postbuild": "npm run minify",
     "preparerelease": "npm run prebuild && npm run build && npm run postbuild && git add dist/* && git commit -m 'update dist'",
     "prerelease": "mversion prerelease && npm run preparerelease",
@@ -33,7 +33,7 @@
     "open": "opener http://localhost:8000/demo/",
     "live-reload": "live-reload --port 8001 dist/",
     "dev": "npm run build && npm run open -s & parallelshell 'npm run live-reload -s' 'npm run serve -s' 'npm run watch -s'",
-    "babel": "babel src --out-dir lib"
+    "babel": "rimraf lib/* && babel src --out-dir lib"
   },
   "devDependencies": {
     "arraybuffer-equal": "^1.0.4",
@@ -43,6 +43,7 @@
     "babel-register": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
+    "browserify-derequire": "^0.9.4",
     "browserify-versionify": "^1.0.6",
     "deep-strict-equal": "^0.2.0",
     "exorcist": "^0.4.0",


### PR DESCRIPTION
Should fix issue if hls.js is used externally in a project that is built with browserify.

https://github.com/dailymotion/hls.js/issues/265#issuecomment-244400294
refs #265 

This also adds `rimraf lib/*` before babel runs as the babel command doesn't clear the directory itself.