### PR TITLE
Do not try to merge fragment details when the playlist is empty for live

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -810,7 +810,7 @@ class StreamController extends EventHandler {
 
     if (newDetails.live) {
       var curDetails = curLevel.details;
-      if (curDetails) {
+      if (curDetails && newDetails.fragments.length > 0) {
         // we already have details for that level, merge them
         LevelHelper.mergeDetails(curDetails,newDetails);
         sliding = newDetails.fragments[0].start;


### PR DESCRIPTION
Fix runtime error raised when a live goes offair: `TypeError: Cannot read property 'start' of undefined`.