### PR TITLE
Start http-server in functional test instead of separate process

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "watch": "watchify --debug -s Hls src/index.js -t [babelify] -o dist/hls.js",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-register --recursive tests/unit",
-    "testfunc": "npm run serve & mocha --compilers js:babel-register --recursive tests/functional/auto --timeout 30000",
+    "testfunc": "mocha --compilers js:babel-register --recursive tests/functional/auto --timeout 30000",
     "lint": "jshint src/",
     "serve": "http-server -p 8000 .",
     "open": "opener http://localhost:8000/demo/",

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -1,5 +1,14 @@
 var assert = require("assert");
 var webdriver = require("selenium-webdriver");
+// requiring this automatically adds the chromedriver binary to the PATH
+var chromedriver = require("chromedriver");
+var HttpServer = require("http-server");
+
+HttpServer.createServer({
+  showDir: false,
+  autoIndex: false,
+  root: './',
+}).listen(8000, '0.0.0.0');
 
 describe("testing hls.js playback in the browser", function() {
   beforeEach(function() {

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -8,7 +8,7 @@ HttpServer.createServer({
   showDir: false,
   autoIndex: false,
   root: './',
-}).listen(8000, '0.0.0.0');
+}).listen(8000, '127.0.0.1');
 
 describe("testing hls.js playback in the browser", function() {
   beforeEach(function() {


### PR DESCRIPTION
This works on windows.

(Also requiring chrome driver so loads from node_modules)