### PR TITLE
add 100ms tolerance to isBuffered check in _onError of stream controller

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1169,7 +1169,8 @@ class StreamController extends EventHandler {
           }
           if (loadError <= this.config.fragLoadingMaxRetry ||
             // keep retrying / don't raise fatal network error if current position is buffered
-            (this.media && this.isBuffered(this.media.currentTime))) {
+            // add 100ms tolerance
+            (this.media && this.isBuffered(this.media.currentTime + 0.1))) {
             this.fragLoadError = loadError;
             // reset load counter to avoid frag loop loading error
             frag.loadCounter = 0;


### PR DESCRIPTION
The issue is there can be cases where the currentTime is less than the buffered.end, but by very little (<100ms), and yet, if the next fragment cannot load due to some error, StreamController._onError() never triggers a fatal event because it thinks there is still some buffer left. 

I noticed the same tolerance was added to an isBuffered call in StreamController._checkFragmentChanged().

Here is a sample showing the issue. Let playback begin and then seek over the first chapter mark. (If you let playback run without seeking, it works fine.) You'll notice never-ending errors in the console:
http://www.theplatcal.com/hlsjs_bug/samples/jg/bad_frag_midroll.html

This page has the fix in it:
http://www.theplatcal.com/hlsjs/samples/jg/bad_frag_midroll.html
