### PR TITLE
Move functional test html script into head so that it blocks page load

### DIFF
--- a/tests/functional/auto/hlsjs.html
+++ b/tests/functional/auto/hlsjs.html
@@ -1,10 +1,7 @@
 <html>
    <head>
       <script src="/dist/hls.js"></script>
-    </head>
-    <body>
-      <video id="video"></video>
-      <script>
+       <script>
         var video, hls;
 
         function startStream(streamUrl, callback) {
@@ -36,6 +33,9 @@
             callback('notSupported');
           }
         }
-      </script>
+       </script>
+    </head>
+    <body>
+      <video id="video"></video>
     </body>
  </html>


### PR DESCRIPTION
Should fix sauce labs error when can't find `startStream()` function.