### PR TITLE
Change 'negative duration computed' log message level from 'error' to…

### DIFF
--- a/src/helper/level-helper.js
+++ b/src/helper/level-helper.js
@@ -117,12 +117,12 @@ class LevelHelper {
       if (toIdx > fromIdx) {
         fragFrom.duration = fragToPTS-fragFrom.start;
         if(fragFrom.duration < 0) {
-          logger.error(`negative duration computed for frag ${fragFrom.sn},level ${fragFrom.level}, there should be some duration drift between playlist and fragment!`);
+          logger.warn(`negative duration computed for frag ${fragFrom.sn},level ${fragFrom.level}, there should be some duration drift between playlist and fragment!`);
         }
       } else {
         fragTo.duration = fragFrom.start - fragToPTS;
         if(fragTo.duration < 0) {
-          logger.error(`negative duration computed for frag ${fragTo.sn},level ${fragTo.level}, there should be some duration drift between playlist and fragment!`);
+          logger.warn(`negative duration computed for frag ${fragTo.sn},level ${fragTo.level}, there should be some duration drift between playlist and fragment!`);
         }
       }
     } else {


### PR DESCRIPTION
… 'warn'

This is the result of our discussion at https://github.com/mangui/flashls/issues/381 (yes that was in flashls, not hls.js).