### PR TITLE
Speed up travis jobs by only running parts that are necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,29 @@
 language: node_js
 node_js:
 - 5.4.1
-script: npm install && npm run build && npm run testfunc
+script: ./scripts/travis.sh
 env:
   global:
     - SAUCE_USERNAME=mangui
   matrix:
-    - TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=arte
-    - TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=arte
-    - TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=arte
-    - TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunnyABR
-    - TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunnyABR
-    - TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunnyABR
-    - TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunny480p
-    - TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunny480p
-    - TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunny480p
-    - TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=issue666
-    - TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=issue666
-    - TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=issue666
-    - TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=nasa
-    - TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=nasa
-    - TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=nasa
+    - TRAVIS_MODE=buildLib
+    - TRAVIS_MODE=buildDist
+    - TRAVIS_MODE=unitTests
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=arte
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=arte
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=arte
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunnyABR
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunnyABR
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunnyABR
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunny480p
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunny480p
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=bigBuckBunny480p
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=issue666
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=issue666
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=issue666
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=chrome        TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=nasa
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=MicrosoftEdge TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=nasa
+    - TRAVIS_MODE=funcTests TEST_BROWSER_NAME=firefox       TEST_BROWSER_PLATFORM="Windows 10" TEST_STREAM_ID=nasa
 addons: 
   sauce_connect: true
   jwt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
 - 5.4.1
+# don't connect to sauce labs unless running functional tests
+before_install: if [ "${TRAVIS_MODE}" != "funcTests" ]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY; fi
 before_script: chmod +x ./scripts/*.sh
 script: ./scripts/travis.sh
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - 5.4.1
+before_script: chmod +x ./scripts/*.sh
 script: ./scripts/travis.sh
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
   "main": "./dist/hls.js",
   "private": false,
   "scripts": {
-    "clean": "rimraf dist/*",
-    "prebuild": "npm run clean && npm run test",
-    "build": "npm run babel && browserify -t browserify-versionify -t [babelify] -p browserify-derequire -p bundle-collapser/plugin -s Hls src/index.js --debug | exorcist dist/hls.js.map -b . > dist/hls.js",
-    "postbuild": "npm run minify",
-    "preparerelease": "npm run prebuild && npm run build && npm run postbuild && git add dist/* && git commit -m 'update dist'",
+    "build": "npm run buildlib && npm run builddist",
+    "buildlib": "rimraf lib/* && babel src --out-dir lib",
+    "builddist": "rimraf dist/* && browserify -t browserify-versionify -t [babelify] -p browserify-derequire -p bundle-collapser/plugin -s Hls src/index.js --debug | exorcist dist/hls.js.map -b . > dist/hls.js && npm run minify",
+    "preparerelease": "npm run build && npm run test && git add dist/* && git commit -m 'update dist'",
     "prerelease": "mversion prerelease && npm run preparerelease",
     "patch": "mversion p && npm run preparerelease",
     "minor": "mversion mi && npm run preparerelease",
@@ -33,8 +32,7 @@
     "serve": "http-server -p 8000 .",
     "open": "opener http://localhost:8000/demo/",
     "live-reload": "live-reload --port 8001 dist/",
-    "dev": "npm run build && npm run open -s & parallelshell 'npm run live-reload -s' 'npm run serve -s' 'npm run watch -s'",
-    "babel": "rimraf lib/* && babel src --out-dir lib"
+    "dev": "npm run build && npm run open -s & parallelshell 'npm run live-reload -s' 'npm run serve -s' 'npm run watch -s'"
   },
   "devDependencies": {
     "arraybuffer-equal": "^1.0.4",

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
 set -ev
+
 npm install
 if [ "${TRAVIS_MODE}" = "buildLib" ]; then
 	npm run buildlib
@@ -15,7 +16,7 @@ elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
 	until [ $n -ge ${maxRetries} ]
 	do
 		if [ $n -gt 0 ]; then
-			echo "Retrying... Attempt: ${n+1}"
+			echo "Retrying... Attempt: $((n+1))"
 		fi
 		npm run testfunc && break
 		n=$[$n+1]

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
+set -ev
+npm install
+if [ "${TRAVIS_MODE}" = "buildLib" ]; then
+	npm run buildlib
+elif [ "${TRAVIS_MODE}" = "buildDist" ]; then
+	npm run builddist
+elif [ "${TRAVIS_MODE}" = "unitTests" ]; then
+	npm run test
+elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
+	npm run builddist
+	npm run testfunc
+else
+	echo "Unknown travis mode: ${TRAVIS_MODE}" 1>&2
+	exit 1
+fi

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -15,7 +15,7 @@ elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
 	until [ $n -ge ${maxRetries} ]
 	do
 		if [ $n -gt 0 ]; then
-			echo "Retrying... Attempt: ${n}"
+			echo "Retrying... Attempt: ${n+1}"
 		fi
 		npm run testfunc && break
 		n=$[$n+1]

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -10,7 +10,19 @@ elif [ "${TRAVIS_MODE}" = "unitTests" ]; then
 	npm run test
 elif [ "${TRAVIS_MODE}" = "funcTests" ]; then
 	npm run builddist
-	npm run testfunc
+	n=0
+	maxRetries=3
+	until [ $n -ge ${maxRetries} ]
+	do
+		if [ $n -gt 0 ]; then
+			echo "Retrying... Attempt: ${n}"
+		fi
+		npm run testfunc && break
+		n=$[$n+1]
+	done
+	if [ ${n} = ${maxRetries} ]; then
+		exit 1
+	fi
 else
 	echo "Unknown travis mode: ${TRAVIS_MODE}" 1>&2
 	exit 1

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -64,10 +64,14 @@ describe('testing hls.js playback in the browser with "'+stream.description+'" o
     }
     this.browser = this.browser.withCapabilities(capabilities).build();
     this.browser.manage().timeouts().setScriptTimeout(40000);
+    console.log("Retrieving web driver session...");
     return this.browser.getSession().then(function(session) {
       console.log("Web driver session id: "+session.getId());
+      console.log("Loading test page...");
       return this.browser.get('http://localhost:8000/tests/functional/auto/hlsjs.html');
-    }.bind(this));
+    }.bind(this)).then(function() {
+      console.log("Test page loaded.");
+    });
   });
 
   afterEach(function() {

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -75,7 +75,10 @@ describe('testing hls.js playback in the browser with "'+stream.description+'" o
   });
 
   afterEach(function() {
-    return this.browser.quit();
+    console.log("Quitting browser...");
+    return this.browser.quit().then(function() {
+      console.log("Browser quit.");
+    });
   });
 
   it('should receive video loadeddata event', function() {

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -46,7 +46,8 @@ describe('testing hls.js playback in the browser with "'+stream.description+'" o
     var capabilities = {
       browserName : browserConfig.name,
       platform : browserConfig.platform,
-      version: browserConfig.version
+      version : browserConfig.version,
+      commandTimeout : 5
     };
     if (onTravis) {
       capabilities['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -47,7 +47,7 @@ describe('testing hls.js playback in the browser with "'+stream.description+'" o
       browserName : browserConfig.name,
       platform : browserConfig.platform,
       version : browserConfig.version,
-      commandTimeout : 5
+      commandTimeout : 25
     };
     if (onTravis) {
       capabilities['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;

--- a/tests/functional/auto/hlsjs.js
+++ b/tests/functional/auto/hlsjs.js
@@ -47,7 +47,10 @@ describe('testing hls.js playback in the browser with "'+stream.description+'" o
       browserName : browserConfig.name,
       platform : browserConfig.platform,
       version : browserConfig.version,
-      commandTimeout : 25
+      commandTimeout : 25,
+      customData : {
+        stream : stream
+      }
     };
     if (onTravis) {
       capabilities['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;


### PR DESCRIPTION
I've removed the "babel" script as this is now in "buildlib".

Also removed "prebuild" and "postbuild" as the contents of those has now moved into the new "buildlib" and "builddist" scripts. I'm not really sure what the advantage of the pre* and post* scripts are over having the commands in one?

Travis now runs "scripts/travis.sh" which will look at `TRAVIS_MODE` and decide what to do from that.
