### PR TITLE
No BUFFER_STALLED_ERROR in IE11/EDGE

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -1302,7 +1302,7 @@ _checkBuffer() {
             expectedPlaying = !(media.paused || // not playing when media is paused
                                 media.ended  || // not playing when media is ended
                                 media.buffered.length === 0), // not playing if nothing buffered
-            jumpThreshold = 0.4, // tolerance needed as some browsers stalls playback before reaching buffered range end
+            jumpThreshold = 0.5, // tolerance needed as some browsers stalls playback before reaching buffered range end
             playheadMoving = currentTime > media.playbackRate*this.lastCurrentTime;
 
         if (this.stalled && playheadMoving) {


### PR DESCRIPTION
Jump threshold of 0.4 is too small for IE11/EDGE both browsers can stall playback while having a bufferInfo.len of 0.44.

This fixes issue:
https://github.com/dailymotion/hls.js/issues/753