### PR TITLE
Split codecs by space or comma instead of just comma

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -106,7 +106,7 @@ class PlaylistLoader extends EventHandler {
 
       var codecs = attrs.CODECS;
       if(codecs) {
-        codecs = codecs.split(',');
+        codecs = codecs.split(/[ ,]+/);
         for (let i = 0; i < codecs.length; i++) {
           const codec = codecs[i];
           if (codec.indexOf('avc1') !== -1) {


### PR DESCRIPTION
👋
Test stream: `//playertest.longtailvideo.com/adaptive/bunny/manifest.m3u8`

Codecs are sometimes separated by spaces, causing hls.js to report that there is no audio stream. This results in the buffer-controller expecting to create only one source buffer. This used prevent playback, but https://github.com/dailymotion/hls.js/commit/e56c646177761f8817b27c76fe17ed805752fb07 has fixed that.
