### PR TITLE
Initial live manifest size

### DIFF
--- a/API.md
+++ b/API.md
@@ -174,6 +174,7 @@ configuration parameters could be provided to hls.js upon instantiation of Hls O
       capLevelToPlayerSize: false,
       debug : false,
       defaultAudioCodec : undefined,
+      initialLiveManifestSize: 1,
       maxBufferLength : 30,
       maxMaxBufferLength : 600,
       maxBufferSize : 60*1000*1000,
@@ -253,6 +254,11 @@ a logger object could also be provided for custom logging : ```config.debug=cust
   - ```mp4a.40.2``` (AAC-LC) or 
   - ```mp4a.40.5``` (HE-AAC) or
   - ```undefined``` (guess based on sampling rate)
+
+#### ```initialLiveManifestSize```
+(default 1)
+
+number of segments needed to start a playback of Live stream.
 
 #### ```maxBufferLength```
 (default 30s)

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -211,6 +211,12 @@ class StreamController extends EventHandler {
 
             // in case of live playlist we need to ensure that requested position is not located before playlist start
           if (levelDetails.live) {
+
+            if(fragLen < config.initialLiveManifestSize){
+              logger.warn(`Can not start playback of a level, reason: not enough fragments ${fragLen} < ${config.initialLiveManifestSize}`);
+              break;
+            }
+
             // check if requested position is within seekable boundaries :
             //logger.log(`start/pos/bufEnd/seeking:${start.toFixed(3)}/${pos.toFixed(3)}/${bufferEnd.toFixed(3)}/${media.seeking}`);
             let maxLatency = config.liveMaxLatencyDuration !== undefined ? config.liveMaxLatencyDuration : config.liveMaxLatencyDurationCount*levelDetails.targetduration;

--- a/src/hls.js
+++ b/src/hls.js
@@ -46,6 +46,7 @@ class Hls {
           startPosition: -1,
           debug: false,
           capLevelToPlayerSize: false,
+          initialLiveManifestSize: 1,
           maxBufferLength: 30,
           maxBufferSize: 60 * 1000 * 1000,
           maxBufferHole: 0.5,


### PR DESCRIPTION
- Add an extra condition to prevent further playback if we don't have enough segments.