### PR TITLE
Clamp 608 captions position between 0 and 100

### DIFF
--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -51,7 +51,8 @@ var Cues = {
           cue.line = (r > 7 ? r - 2 : r + 1);
         }
         cue.align = 'left';
-        cue.position = 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0);
+        // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
+        cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0)));
         track.addCue(cue);
       }
     }


### PR DESCRIPTION
Test stream: playertest.longtailvideo.com/adaptive/captions/playlist.m3u8

In Firefox, a cue in this stream's caption has its position set to over 100, causing an exception to be thrown. This causes caption processing to freeze (cueStartTime never gets changed). Clamp the value between 0 and 100 to prevent the exception.