### PR TITLE
Clear out orphaned roll-up captions

### DIFF
--- a/src/utils/cea-608-parser.js
+++ b/src/utils/cea-608-parser.js
@@ -500,12 +500,32 @@ class CaptionScreen {
         row.setCursor(absPos);
     }
 
-    setPAC(pacData) {
+    setPAC(pacData, lastOutputScreen) {
         logger.log('INFO', 'pacData = ' + JSON.stringify(pacData));
         var newRow = pacData.row - 1;
         if (this.nrRollUpRows  && newRow < this.nrRollUpRows - 1) {
                 newRow = this.nrRollUpRows-1;
         }
+
+        if (this.currRow !== newRow) {
+          //clear all rows first
+          for (var i = 0; i < NR_ROWS; i++) {
+            this.rows[i].clear();
+          }
+
+          //Copy this.nrRollUpRows rows from lastOutputScreen and place it in the newRow location
+          //topRowIndex - the start of rows to copy (inclusive index)
+          var topRowIndex = this.currRow + 1 - (this.nrRollUpRows);
+          //We only copy if the last position was already shown.
+          //We use the cueStartTime to check this.
+          var prevLineTime = lastOutputScreen.rows[topRowIndex].cueStartTime;
+          if(prevLineTime && prevLineTime < logger.time) {
+            for (i = 0; i < this.nrRollUpRows; i++) {
+              this.rows[newRow-this.nrRollUpRows+i+1].copy(lastOutputScreen.rows[topRowIndex+i]);
+            }
+          }
+        }
+
         this.currRow = newRow;
         var row = this.rows[this.currRow];
         if (pacData.indent !== null) {
@@ -621,7 +641,7 @@ class Cea608Channel
     }
 
     setPAC(pacData) {
-        this.writeScreen.setPAC(pacData);
+        this.writeScreen.setPAC(pacData, this.lastOutputScreen);
     }
 
     setBkgData(bkgData) {
@@ -639,6 +659,7 @@ class Cea608Channel
         } else {
             this.writeScreen = this.displayedMemory;
             this.writeScreen.reset();
+            this.lastOutputScreen.reset();
         }
         if (this.mode !== 'MODE_ROLL-UP') {
             this.displayedMemory.nrRollUpRows = null;

--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -29,6 +29,8 @@ var Cues = {
             indenting = false;
           }
         }
+        //To be used for cleaning-up orphaned roll-up captions
+        row.cueStartTime = startTime;
         cue = new VTTCue(startTime, endTime, text.trim());
 
         if (indent >= 16)


### PR DESCRIPTION
The current code messes up the display of roll-up captions when a new cursor position is set by a PAC caption command. 

You can see the problem in the following stream:
http://player.theplatform.com/p/RIyUFC/t91QYYYzNgwm/select/media/DVYuc3Ngr7iK?form=html&logLevel=debug&pdk=stage

My pull request code clears up the displayedMemory CaptionScreen when a new cursor position is set and it also tries to merge the remaining lines from the previous position into the new position.
 