### PR TITLE
Fix manifest level parsing with spaces before numeric values

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -213,7 +213,7 @@ class PlaylistLoader extends EventHandler {
         byteRangeStartOffset = null,
         tagList = [];
 
-    regexp = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):(\d+))|(?:#EXT-X-(TARGETDURATION):(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT(INF):(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE):(\d+(?:@\d+(?:\.\d+)?)?)|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.+))|(?:#EXT-X-(VERSION):(\d+))|(?:(#)(.*):(.*))|(?:(#)(.*)))(?:.*)\r?\n?/g;
+    regexp = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE):\s*(\d+))|(?:#EXT-X-(TARGETDURATION):\s*(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT(INF):\s*(\d+(?:\.\d+)?)(?:,(.*))?)|(?:(?!#)()(\S.+))|(?:#EXT-X-(BYTERANGE):\s*(\d+(?:@\d+(?:\.\d+)?)?)|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(PROGRAM-DATE-TIME):(.+))|(?:#EXT-X-(VERSION):(\d+))|(?:(#)(.*):(.*))|(?:(#)(.*)))(?:.*)\r?\n?/g;
     while ((result = regexp.exec(string)) !== null) {
       result.shift();
       result = result.filter(function(n) { return (n !== undefined); });
@@ -361,10 +361,14 @@ class PlaylistLoader extends EventHandler {
           hls.trigger(Event.MANIFEST_LOADED, {levels: [{url: url, details : levelDetails}], audioTracks : [], url: url, stats: stats});
         }
         stats.tparsed = performance.now();
-        if (isLevel) {
-          hls.trigger(Event.LEVEL_LOADED, {details: levelDetails, level: level || 0, id: id || 0, stats: stats});
+        if (levelDetails.targetduration && levelDetails.totalduration) {
+          if (isLevel) {
+            hls.trigger(Event.LEVEL_LOADED, {details: levelDetails, level: level || 0, id: id || 0, stats: stats});
+          } else {
+            hls.trigger(Event.AUDIO_TRACK_LOADED, {details: levelDetails, id: id, stats: stats});
+          }
         } else {
-          hls.trigger(Event.AUDIO_TRACK_LOADED, {details: levelDetails, id: id, stats: stats});
+          hls.trigger(Event.ERROR, {type: ErrorTypes.NETWORK_ERROR, details: ErrorDetails.MANIFEST_PARSING_ERROR, fatal: true, url: url, reason: 'no duration found in level'});
         }
       } else {
         let levels = this.parseMasterPlaylist(string, url);


### PR DESCRIPTION
Adds support for level manifests which contain spaces before TARGETDURATION and EXTINF durations as well as MEDIA/DISCONTINUITY-SEQUENCE numbers and BYTERANGE tags.

Even though this strictly does not follow the HLS spec, the following stream is supported by Safari. 

http://qa.jwplayer.com/~todd/pluto/master.m3u8
```
#EXTM3U
#EXT-X-VERSION:2
#EXT-X-TARGETDURATION: 10
#EXT-X-MEDIA-SEQUENCE: 1
#EXT-X-DISCONTINUITY-SEQUENCE: 0
#ANVATO-SEGMENT-INFO: type=master
#EXTINF: 10, 1:0
segment_144597148.ts
```

When target duration is not parsed, a value of 0 on a Live stream causes the manifest to be constantly reloaded without delay. To avoid this condition, both `targetduration` and `totalduration` must be truthy otherwise throw a fatal NETWORK_ERROR with MANIFEST_PARSING_ERROR details and 'no duration found in level' reason.