### PR TITLE
use latest stable node version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-node_js:
-- 5.4.1
+node_js: node
 # don't connect to sauce labs unless running functional tests
 before_install: if [ "${TRAVIS_MODE}" != "funcTests" ]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY; fi
 before_script: chmod +x ./scripts/*.sh


### PR DESCRIPTION
Shouldn't do any harm, and wondering if this might fix sauce labs if it uses a more recent docker image. Travis says the image that the previous jobs were running on was created on Thu Feb 5 15:09:33 UTC 2015