### PR TITLE
Add auto positionAlign for new VTT Cues

### DIFF
--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -53,6 +53,7 @@ var Cues = {
           cue.line = (r > 7 ? r - 2 : r + 1);
         }
         cue.align = 'left';
+        cue.positionAlign = 'auto';
         // Clamp the position between 0 and 100 - if out of these bounds, Firefox throws an exception and captions break
         cue.position = Math.max(0, Math.min(100, 100 * (indent / 32) + (navigator.userAgent.match(/Firefox\//) ? 50 : 0)));
         track.addCue(cue);


### PR DESCRIPTION
NOTE: this is to address mis-aligned captions when using vtt.js library to polyfill VTTCue. The default vtt.js implementation uses a default positionAlign="middle" which causes left aligned captions to render partially off-screen.