### PR TITLE
Move url-toolkit to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,9 @@
     "parallelshell": "^2.0.0",
     "rimraf": "^2.5.1",
     "uglify-js": "^2.7.4",
+    "url-toolkit": "^1.0.4",
     "selenium-webdriver": "^2.52.0",
     "watchify": "^3.7.0",
     "webworkify": "^1.4.0"
-  },
-  "dependencies": {
-    "url-toolkit": "^1.0.4"
   }
 }


### PR DESCRIPTION
I accidentally installed it to dependencies.