### PR TITLE
[Addition] minAutoBitrate upgrade #841

### DIFF
--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -94,7 +94,7 @@ class AbrController extends EventHandler {
           let fragLevelNextLoadedDelay, nextLoadLevel;
           // lets iterate through lower level and try to find the biggest one that could avoid rebuffering
           // we start from current level - 1 and we step down , until we find a matching level
-          for (nextLoadLevel = frag.level - 1 ; nextLoadLevel >=0 ; nextLoadLevel--) {
+          for (nextLoadLevel = frag.level - 1 ; nextLoadLevel > this.minAutoLevel ; nextLoadLevel--) {
             // compute time to load next fragment at lower level
             // 0.8 : consider only 80% of current bw to be conservative
             // 8 = bits per byte (bps/Bps)
@@ -108,7 +108,7 @@ class AbrController extends EventHandler {
           // of finishing loading current one ...
           if (fragLevelNextLoadedDelay < fragLoadedDelay) {
             // ensure nextLoadLevel is not negative
-            nextLoadLevel = Math.max(0,nextLoadLevel);
+            nextLoadLevel = Math.max(this.minAutoLevel,nextLoadLevel);
             logger.warn(`loading too slow, abort fragment loading and switch to level ${nextLoadLevel}:fragLoadedDelay[${nextLoadLevel}]<fragLoadedDelay[${frag.level-1}];bufferStarvationDelay:${fragLevelNextLoadedDelay.toFixed(1)}<${fragLoadedDelay.toFixed(1)}:${bufferStarvationDelay.toFixed(1)}`);
             // force next load level in auto mode
             hls.nextLoadLevel = nextLoadLevel;

--- a/src/controller/abr-controller.js
+++ b/src/controller/abr-controller.js
@@ -64,7 +64,7 @@ class AbrController extends EventHandler {
       we compute expected time of arrival of the complete fragment.
       we compare it to expected time of buffer starvation
     */
-    let hls = this.hls, v = hls.media,frag = this.fragCurrent, loader = frag.loader;
+    let hls = this.hls, v = hls.media,frag = this.fragCurrent, loader = frag.loader, minAutoLevel = this.minAutoLevel;
 
     // if loader has been destroyed or loading has been aborted, stop timer and return
     if(!loader || ( loader.stats && loader.stats.aborted)) {
@@ -94,7 +94,7 @@ class AbrController extends EventHandler {
           let fragLevelNextLoadedDelay, nextLoadLevel;
           // lets iterate through lower level and try to find the biggest one that could avoid rebuffering
           // we start from current level - 1 and we step down , until we find a matching level
-          for (nextLoadLevel = frag.level - 1 ; nextLoadLevel > this.minAutoLevel ; nextLoadLevel--) {
+          for (nextLoadLevel = frag.level - 1 ; nextLoadLevel > minAutoLevel ; nextLoadLevel--) {
             // compute time to load next fragment at lower level
             // 0.8 : consider only 80% of current bw to be conservative
             // 8 = bits per byte (bps/Bps)
@@ -108,7 +108,7 @@ class AbrController extends EventHandler {
           // of finishing loading current one ...
           if (fragLevelNextLoadedDelay < fragLoadedDelay) {
             // ensure nextLoadLevel is not negative
-            nextLoadLevel = Math.max(this.minAutoLevel,nextLoadLevel);
+            nextLoadLevel = Math.max(minAutoLevel,nextLoadLevel);
             logger.warn(`loading too slow, abort fragment loading and switch to level ${nextLoadLevel}:fragLoadedDelay[${nextLoadLevel}]<fragLoadedDelay[${frag.level-1}];bufferStarvationDelay:${fragLevelNextLoadedDelay.toFixed(1)}<${fragLoadedDelay.toFixed(1)}:${bufferStarvationDelay.toFixed(1)}`);
             // force next load level in auto mode
             hls.nextLoadLevel = nextLoadLevel;

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -187,8 +187,7 @@ class LevelController extends EventHandler {
   }
 
   set startLevel(newLevel) {
-    let hls = this.hls, abrController = hls.abrController, minAutoLevel = abrController.minAutoLevel;
-    this._startLevel = Math.max(newLevel, minAutoLevel);
+    this._startLevel = Math.max(newLevel, this.hls.abrController.minAutoLevel);
   }
 
   onError(data) {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -229,7 +229,7 @@ class LevelController extends EventHandler {
         let recoverable = ((this._manualLevel === -1) && levelId);
         if (recoverable) {
           logger.warn(`level controller,${details}: emergency switch-down for next fragment`);
-          hls.abrController.nextAutoLevel = minAutoLevel;
+          abrController.nextAutoLevel = minAutoLevel;
         } else if(level && level.details && level.details.live) {
           logger.warn(`level controller,${details} on live stream, discard`);
           if (levelError) {
@@ -239,8 +239,7 @@ class LevelController extends EventHandler {
           // other errors are handled by stream controller
         } else if (details === ErrorDetails.LEVEL_LOAD_ERROR ||
                    details === ErrorDetails.LEVEL_LOAD_TIMEOUT) {
-          let hls = this.hls,
-              media = hls.media,
+          let media = hls.media,
             // 0.5 : tolerance needed as some browsers stalls playback before reaching buffered end
               mediaBuffered = media && BufferHelper.isBuffered(media,media.currentTime) && BufferHelper.isBuffered(media,media.currentTime+0.5);
           if (mediaBuffered) {

--- a/src/controller/level-controller.js
+++ b/src/controller/level-controller.js
@@ -187,7 +187,8 @@ class LevelController extends EventHandler {
   }
 
   set startLevel(newLevel) {
-    this._startLevel = newLevel;
+    let hls = this.hls, abrController = hls.abrController, minAutoLevel = abrController.minAutoLevel;
+    this._startLevel = Math.max(newLevel, minAutoLevel);
   }
 
   onError(data) {
@@ -195,7 +196,7 @@ class LevelController extends EventHandler {
       return;
     }
 
-    let details = data.details, hls = this.hls, levelId, level, levelError = false;
+    let details = data.details, hls = this.hls, levelId, level, levelError = false, abrController = hls.abrController, minAutoLevel = abrController.minAutoLevel;
     // try to recover not fatal errors
     switch(details) {
       case ErrorDetails.FRAG_LOAD_ERROR:
@@ -228,7 +229,7 @@ class LevelController extends EventHandler {
         let recoverable = ((this._manualLevel === -1) && levelId);
         if (recoverable) {
           logger.warn(`level controller,${details}: emergency switch-down for next fragment`);
-          hls.abrController.nextAutoLevel = 0;
+          hls.abrController.nextAutoLevel = minAutoLevel;
         } else if(level && level.details && level.details.live) {
           logger.warn(`level controller,${details} on live stream, discard`);
           if (levelError) {

--- a/src/hls.js
+++ b/src/hls.js
@@ -294,7 +294,8 @@ class Hls {
   /** Return first level (index of first level referenced in manifest)
   **/
   get firstLevel() {
-    return this.levelController.firstLevel;
+    let minAutoLevel = this.abrController.minAutoLevel;
+    return Math.max(this.levelController.firstLevel,minAutoLevel);
   }
 
   /** set first level (index of first level referenced in manifest)
@@ -318,7 +319,8 @@ class Hls {
   **/
   set startLevel(newLevel) {
     logger.log(`set startLevel:${newLevel}`);
-    this.levelController.startLevel = newLevel;
+    let minAutoLevel = this.abrController.minAutoLevel;
+    this.levelController.startLevel = Math.max(newLevel,minAutoLevel);
   }
 
   /** Return the capping/max level value that could be used by automatic level selection algorithm **/

--- a/src/hls.js
+++ b/src/hls.js
@@ -294,8 +294,7 @@ class Hls {
   /** Return first level (index of first level referenced in manifest)
   **/
   get firstLevel() {
-    let minAutoLevel = this.abrController.minAutoLevel;
-    return Math.max(this.levelController.firstLevel,minAutoLevel);
+    return Math.max(this.levelController.firstLevel, this.abrController.minAutoLevel);
   }
 
   /** set first level (index of first level referenced in manifest)


### PR DESCRIPTION
Fix for issues #841
When using minAutoBitrate video should start not with the lowest level but with the lowest lewel above minAutoBitrate
Additionally found out that when throttling network to low bandwidh - abandonRulesCheck is forcing to go down to the lowest level