### PR TITLE
Reset lastIndex on regex expressions with g flag before use

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -92,6 +92,7 @@ class PlaylistLoader extends EventHandler {
 
   parseMasterPlaylist(string, baseurl) {
     let levels = [], result;
+    MASTER_PLAYLIST_REGEX.lastIndex = 0;
     while ((result = MASTER_PLAYLIST_REGEX.exec(string)) != null){
       const level = {};
 
@@ -126,6 +127,7 @@ class PlaylistLoader extends EventHandler {
 
   parseMasterPlaylistMedia(string, baseurl, type) {
     let result, medias = [];
+    MASTER_PLAYLIST_MEDIA_REGEX.lastIndex = 0;
     while ((result = MASTER_PLAYLIST_MEDIA_REGEX.exec(string)) != null){
       const media = {};
       var attrs = new AttrList(result[1]);
@@ -211,6 +213,7 @@ class PlaylistLoader extends EventHandler {
         byteRangeStartOffset = null,
         tagList = [];
 
+    LEVEL_PLAYLIST_REGEX.lastIndex = 0;
     while ((result = LEVEL_PLAYLIST_REGEX.exec(string)) !== null) {
       result.shift();
       result = result.filter(function(n) { return (n !== undefined); });

--- a/src/utils/attr-list.js
+++ b/src/utils/attr-list.js
@@ -67,6 +67,7 @@ class AttrList {
 
   static parseAttrList(input) {
     var match, attrs = {};
+    ATTR_LIST_REGEX.lastIndex = 0;
     while ((match = ATTR_LIST_REGEX.exec(input)) !== null) {
       var value = match[2], quote = '"';
 


### PR DESCRIPTION
Currently if the regex expression was used previously but didn’t run to the end of the string it will resume from where it was previously.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex