### PR TITLE
Release MediaSource object URL when media is detached

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -130,6 +130,7 @@ class BufferController extends EventHandler {
       // Detach properly the MediaSource from the HTMLMediaElement as
       // suggested in https://github.com/w3c/media-source/issues/53.
       if (this.media) {
+        URL.revokeObjectURL(this.media.src);
         this.media.removeAttribute('src');
         this.media.load();
       }


### PR DESCRIPTION
Fixes a memory leak of the MediaSource object created in onMediaAttaching
Problem is similar to issue #780, leak was discovered while taking heap snapshots in Chrome