### PR TITLE
Pushing fix for CC cues not stopping when switching media

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -130,6 +130,8 @@ class TimelineController extends EventHandler {
   }
 
   onMediaDetaching() {
+    this.clearCurrentCues(this.textTrack1);
+    this.clearCurrentCues(this.textTrack2);
   }
 
   onManifestLoading()


### PR DESCRIPTION
When I have two sources with inline CC, swapping between them causes some CC from the previous source to appear mixed in with the CC of the new source, and continue to update. I am calling detachMedia before swapping to the new source. For VOD to VOD swaps, this mixing lasts only for a couple of fragments. For Live to VOD, I am seeing lingering mixing that lasts for a longer time.

By clearing the cues on the detach media listener in TimelineController, it stops the lingering CC cues. I have tested this with VOD to VOD, live to VOD and VOD to live and it appears to solve the issue.