### PR TITLE
Fix for IE11 not dispatching an addtrack event for 608/708 captions.

### DIFF
--- a/src/controller/timeline-controller.js
+++ b/src/controller/timeline-controller.js
@@ -24,6 +24,19 @@ class TimelineController extends EventHandler {
     if (this.config.enableCEA708Captions)
     {
       var self = this;
+      var sendAddTrackEvent = function (track, media)
+      {
+        var e = null;
+        try {
+          e = new window.Event('addtrack');
+        } catch (err) {
+          //for IE11
+          e = document.createEvent('Event');
+          e.initEvent('addtrack', false, false);
+        }
+        e.track = track;
+        media.dispatchEvent(e);
+      };
 
       var channel1 =
       {
@@ -43,9 +56,7 @@ class TimelineController extends EventHandler {
               self.textTrack1 = existingTrack1;
               self.clearCurrentCues(self.textTrack1);
 
-              let e = new window.Event('addtrack');
-              e.track = self.textTrack1;
-              self.media.dispatchEvent(e);
+              sendAddTrackEvent(self.textTrack1, self.media);
             }
           }
 
@@ -71,9 +82,7 @@ class TimelineController extends EventHandler {
               self.textTrack2 = existingTrack2;
               self.clearCurrentCues(self.textTrack2);
 
-              let e = new window.Event('addtrack');
-              e.track = self.textTrack2;
-              self.media.dispatchEvent(e);
+              sendAddTrackEvent(self.textTrack2, self.media);
             }
           }
 


### PR DESCRIPTION
The  `new window.Event('addtrack');` line of code throws an exception in IE11. I added a try-catch expression and called `document.createEvent('Event') ` when an exception is caught.