### PR TITLE
requestIdleCallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,11 @@
     "mversion": "^1.10.1",
     "opener": "^1.4.0",
     "parallelshell": "^2.0.0",
+    "requestidlecallback": "0.3.0",
     "rimraf": "^2.5.1",
+    "selenium-webdriver": "^3.0.0",
     "uglify-js": "^2.7.5",
     "url-toolkit": "^1.0.4",
-    "selenium-webdriver": "^3.0.0",
     "watchify": "^3.7.0",
     "webworkify": "^1.4.0"
   }

--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -128,25 +128,32 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
     assert.strictEqual(result[9]['bitrate'],6221600);
   });
 
-  it('parses empty levels returns empty fragment array', () => {
+  it('parses empty levels returns empty fragment array', (done) => {
     var level = "";
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0);
-    assert.strictEqual(result.fragments.length, 0);
-    assert.strictEqual(result.totalduration,0);
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 0);
+        assert.strictEqual(result.totalduration,0);
+        done();
+      }).catch(done);
   });
 
-  it('level with 0 frag returns empty fragment array', () => {
+  it('level with 0 frag returns empty fragment array', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-PLAYLIST-TYPE:VOD
 #EXT-X-TARGETDURATION:14
 #EXTINF:11.360,`;
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0);
-    assert.strictEqual(result.fragments.length, 0);
-    assert.strictEqual(result.totalduration,0);
+    new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 0);
+        assert.strictEqual(result.totalduration,0);
+        done();
+      }).catch(done);
   });
 
-  it('parse level with several fragments', () => {
+  it('parse level with several fragments', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-PLAYLIST-TYPE:VOD
@@ -163,27 +170,31 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
 #EXTINF:3.880,
 /sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(5)/video/107/282/158282701_mp4_h264_aac_hq.ts
 #EXT-X-ENDLIST`;
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0);
-    assert.strictEqual(result.totalduration, 51.24);
-    assert.strictEqual(result.startSN, 0);
-    assert.strictEqual(result.version, 3);
-    assert.strictEqual(result.type, 'VOD');
-    assert.strictEqual(result.targetduration, 14);
-    assert.strictEqual(result.live, false);
-    assert.strictEqual(result.fragments.length, 5);
-    assert.strictEqual(result.fragments[0].cc, 0);
-    assert.strictEqual(result.fragments[0].duration, 11.36);
-    assert.strictEqual(result.fragments[4].sn, 4);
-    assert.strictEqual(result.fragments[0].level, 0);
-    assert.strictEqual(result.fragments[4].cc, 0);
-    assert.strictEqual(result.fragments[4].sn, 4);
-    assert.strictEqual(result.fragments[4].start, 47.36);
-    assert.strictEqual(result.fragments[4].duration, 3.88);
-    assert.strictEqual(result.fragments[4].url, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(5)/video/107/282/158282701_mp4_h264_aac_hq.ts');
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0)
+      .then(result => {
+        assert.strictEqual(result.totalduration, 51.24);
+        assert.strictEqual(result.startSN, 0);
+        assert.strictEqual(result.version, 3);
+        assert.strictEqual(result.type, 'VOD');
+        assert.strictEqual(result.targetduration, 14);
+        assert.strictEqual(result.live, false);
+        assert.strictEqual(result.fragments.length, 5);
+        assert.strictEqual(result.fragments[0].cc, 0);
+        assert.strictEqual(result.fragments[0].duration, 11.36);
+        assert.strictEqual(result.fragments[4].sn, 4);
+        assert.strictEqual(result.fragments[0].level, 0);
+        assert.strictEqual(result.fragments[4].cc, 0);
+        assert.strictEqual(result.fragments[4].sn, 4);
+        assert.strictEqual(result.fragments[4].start, 47.36);
+        assert.strictEqual(result.fragments[4].duration, 3.88);
+        assert.strictEqual(result.fragments[4].url, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(5)/video/107/282/158282701_mp4_h264_aac_hq.ts');
+        done();
+      }).catch(done);
   });
 
 
-  it('parse level with start time offset', () => {
+  it('parse level with start time offset', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-PLAYLIST-TYPE:VOD
@@ -200,15 +211,19 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
 #EXTINF:3.880,
 /sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(5)/video/107/282/158282701_mp4_h264_aac_hq.ts
 #EXT-X-ENDLIST`;
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0);
-    assert.strictEqual(result.totalduration, 51.24);
-    assert.strictEqual(result.startSN, 0);
-    assert.strictEqual(result.targetduration, 14);
-    assert.strictEqual(result.live, false);
-    assert.strictEqual(result.startTimeOffset, 10.3);
+    var result = new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0)
+      .then(result => {
+        assert.strictEqual(result.totalduration, 51.24);
+        assert.strictEqual(result.startSN, 0);
+        assert.strictEqual(result.targetduration, 14);
+        assert.strictEqual(result.live, false);
+        assert.strictEqual(result.startTimeOffset, 10.3);
+        done();
+      }).catch(done);
   });
 
-  it('parse AES encrypted URLs, with implicit IV', () => {
+  it('parse AES encrypted URLs, with implicit IV', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:1
 ## Created with Unified Streaming Platform(version=1.6.7)
@@ -223,36 +238,40 @@ oceans_aes-audio=65000-video=236000-2.ts
 #EXTINF:7,no desc
 oceans_aes-audio=65000-video=236000-3.ts
 #EXT-X-ENDLIST`;
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://foo.com/adaptive/oceans_aes/oceans_aes.m3u8',0);
-    assert.strictEqual(result.totalduration, 25);
-    assert.strictEqual(result.startSN, 1);
-    assert.strictEqual(result.targetduration, 11);
-    assert.strictEqual(result.live, false);
-    assert.strictEqual(result.fragments.length, 3);
-    assert.strictEqual(result.fragments[0].cc, 0);
-    assert.strictEqual(result.fragments[0].duration, 11);
-    assert.strictEqual(result.fragments[0].title, "no desc");
-    assert.strictEqual(result.fragments[0].level, 0);
-    assert.strictEqual(result.fragments[0].url, 'http://foo.com/adaptive/oceans_aes/oceans_aes-audio=65000-video=236000-1.ts');
-    assert.strictEqual(result.fragments[0].decryptdata.uri, 'http://foo.com/adaptive/oceans_aes/oceans.key');
-    assert.strictEqual(result.fragments[0].decryptdata.method, 'AES-128');
-    var sn = 1;
-    var uint8View = new Uint8Array(16);
-    for (var i = 12; i < 16; i++) {
-      uint8View[i] = (sn >> 8*(15-i)) & 0xff;
-    }
-    assert(bufferIsEqual(result.fragments[0].decryptdata.iv.buffer, uint8View.buffer));
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://foo.com/adaptive/oceans_aes/oceans_aes.m3u8',0)
+      .then(result => {
+        assert.strictEqual(result.totalduration, 25);
+        assert.strictEqual(result.startSN, 1);
+        assert.strictEqual(result.targetduration, 11);
+        assert.strictEqual(result.live, false);
+        assert.strictEqual(result.fragments.length, 3);
+        assert.strictEqual(result.fragments[0].cc, 0);
+        assert.strictEqual(result.fragments[0].duration, 11);
+        assert.strictEqual(result.fragments[0].title, "no desc");
+        assert.strictEqual(result.fragments[0].level, 0);
+        assert.strictEqual(result.fragments[0].url, 'http://foo.com/adaptive/oceans_aes/oceans_aes-audio=65000-video=236000-1.ts');
+        assert.strictEqual(result.fragments[0].decryptdata.uri, 'http://foo.com/adaptive/oceans_aes/oceans.key');
+        assert.strictEqual(result.fragments[0].decryptdata.method, 'AES-128');
+        var sn = 1;
+        var uint8View = new Uint8Array(16);
+        for (var i = 12; i < 16; i++) {
+          uint8View[i] = (sn >> 8*(15-i)) & 0xff;
+        }
+        assert(bufferIsEqual(result.fragments[0].decryptdata.iv.buffer, uint8View.buffer));
 
-    sn = 3;
-    uint8View = new Uint8Array(16);
-    for (var i = 12; i < 16; i++) {
-      uint8View[i] = (sn >> 8*(15-i)) & 0xff;
-    }
-    assert(bufferIsEqual(result.fragments[2].decryptdata.iv.buffer, uint8View.buffer));
+        sn = 3;
+        uint8View = new Uint8Array(16);
+        for (var i = 12; i < 16; i++) {
+          uint8View[i] = (sn >> 8*(15-i)) & 0xff;
+        }
+        assert(bufferIsEqual(result.fragments[2].decryptdata.iv.buffer, uint8View.buffer));
+        done();
+      }).catch(done);
   });
 
 
-  it('parse level with #EXT-X-BYTERANGE before #EXTINF', () => {
+  it('parse level with #EXT-X-BYTERANGE before #EXTINF', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:4
 #EXT-X-ALLOW-CACHE:YES
@@ -289,19 +308,23 @@ lo008ts
 #EXTINF:1000000,
 lo008ts`;
 
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8',0);
-    assert.strictEqual(result.fragments.length, 10);
-    assert.strictEqual(result.fragments[0].url, 'http://dummy.com/lo007ts');
-    assert.strictEqual(result.fragments[0].byteRangeStartOffset,803136);
-    assert.strictEqual(result.fragments[0].byteRangeEndOffset,943196);
-    assert.strictEqual(result.fragments[1].byteRangeStartOffset,943196);
-    assert.strictEqual(result.fragments[1].byteRangeEndOffset,1039452);
-    assert.strictEqual(result.fragments[9].url, 'http://dummy.com/lo008ts');
-    assert.strictEqual(result.fragments[9].byteRangeStartOffset,684508);
-    assert.strictEqual(result.fragments[9].byteRangeEndOffset,817988);
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 10);
+        assert.strictEqual(result.fragments[0].url, 'http://dummy.com/lo007ts');
+        assert.strictEqual(result.fragments[0].byteRangeStartOffset,803136);
+        assert.strictEqual(result.fragments[0].byteRangeEndOffset,943196);
+        assert.strictEqual(result.fragments[1].byteRangeStartOffset,943196);
+        assert.strictEqual(result.fragments[1].byteRangeEndOffset,1039452);
+        assert.strictEqual(result.fragments[9].url, 'http://dummy.com/lo008ts');
+        assert.strictEqual(result.fragments[9].byteRangeStartOffset,684508);
+        assert.strictEqual(result.fragments[9].byteRangeEndOffset,817988);
+        done();
+      }).catch(done);
   });
 
-  it('parse level with #EXT-X-BYTERANGE after #EXTINF', () => {
+  it('parse level with #EXT-X-BYTERANGE after #EXTINF', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:4
 #EXT-X-ALLOW-CACHE:YES
@@ -338,19 +361,23 @@ lo008ts
 #EXT-X-BYTERANGE:133480@684508
 lo008ts`;
 
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8',0);
-    assert.strictEqual(result.fragments.length, 10);
-    assert.strictEqual(result.fragments[0].url, 'http://dummy.com/lo007ts');
-    assert.strictEqual(result.fragments[0].byteRangeStartOffset,803136);
-    assert.strictEqual(result.fragments[0].byteRangeEndOffset,943196);
-    assert.strictEqual(result.fragments[1].byteRangeStartOffset,943196);
-    assert.strictEqual(result.fragments[1].byteRangeEndOffset,1039452);
-    assert.strictEqual(result.fragments[9].url, 'http://dummy.com/lo008ts');
-    assert.strictEqual(result.fragments[9].byteRangeStartOffset,684508);
-    assert.strictEqual(result.fragments[9].byteRangeEndOffset,817988);
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 10);
+        assert.strictEqual(result.fragments[0].url, 'http://dummy.com/lo007ts');
+        assert.strictEqual(result.fragments[0].byteRangeStartOffset,803136);
+        assert.strictEqual(result.fragments[0].byteRangeEndOffset,943196);
+        assert.strictEqual(result.fragments[1].byteRangeStartOffset,943196);
+        assert.strictEqual(result.fragments[1].byteRangeEndOffset,1039452);
+        assert.strictEqual(result.fragments[9].url, 'http://dummy.com/lo008ts');
+        assert.strictEqual(result.fragments[9].byteRangeStartOffset,684508);
+        assert.strictEqual(result.fragments[9].byteRangeEndOffset,817988);
+        done();
+      }).catch(done);
   });
 
-  it('parse level with #EXT-X-BYTERANGE without offset', () => {
+  it('parse level with #EXT-X-BYTERANGE without offset', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:4
 #EXT-X-ALLOW-CACHE:YES
@@ -366,18 +393,22 @@ lo007ts
 #EXT-X-BYTERANGE:143068
 lo007ts`;
 
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8',0);
-    assert.strictEqual(result.fragments.length, 3);
-    assert.strictEqual(result.fragments[0].url, 'http://dummy.com/lo007ts');
-    assert.strictEqual(result.fragments[0].byteRangeStartOffset,803136);
-    assert.strictEqual(result.fragments[0].byteRangeEndOffset,943196);
-    assert.strictEqual(result.fragments[1].byteRangeStartOffset,943196);
-    assert.strictEqual(result.fragments[1].byteRangeEndOffset,1039452);
-    assert.strictEqual(result.fragments[2].byteRangeStartOffset,1039452);
-    assert.strictEqual(result.fragments[2].byteRangeEndOffset,1182520);
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 3);
+        assert.strictEqual(result.fragments[0].url, 'http://dummy.com/lo007ts');
+        assert.strictEqual(result.fragments[0].byteRangeStartOffset,803136);
+        assert.strictEqual(result.fragments[0].byteRangeEndOffset,943196);
+        assert.strictEqual(result.fragments[1].byteRangeStartOffset,943196);
+        assert.strictEqual(result.fragments[1].byteRangeEndOffset,1039452);
+        assert.strictEqual(result.fragments[2].byteRangeStartOffset,1039452);
+        assert.strictEqual(result.fragments[2].byteRangeEndOffset,1182520);
+        done();
+      }).catch(done);
   });
 
-  it('parses discontinuity and maintains continuity counter', () => {
+  it('parses discontinuity and maintains continuity counter', (done) => {
     var level = `#EXTM3U
 #EXTM3U
 #EXT-X-VERSION:3
@@ -396,14 +427,18 @@ lo007ts`;
 0006.ts
 #EXT-X-ENDLIST
     `;
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8',0);
-    assert.strictEqual(result.fragments.length, 5);
-    assert.strictEqual(result.totalduration, 45);
-    assert.strictEqual(result.fragments[2].cc, 0);
-    assert.strictEqual(result.fragments[3].cc, 1); //continuity counter should increase around discontinuity
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 5);
+        assert.strictEqual(result.totalduration, 45);
+        assert.strictEqual(result.fragments[2].cc, 0);
+        assert.strictEqual(result.fragments[3].cc, 1); //continuity counter should increase around discontinuity
+        done();
+      }).catch(done);
   });
 
-  it('parses correctly EXT-X-DISCONTINUITY-SEQUENCE and increases continuity counter', () => {
+  it('parses correctly EXT-X-DISCONTINUITY-SEQUENCE and increases continuity counter', (done) => {
     var level = `#EXTM3U
 #EXTM3U
 #EXT-X-VERSION:3
@@ -423,29 +458,33 @@ lo007ts`;
 0006.ts
 #EXT-X-ENDLIST
     `;
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8',0);
-    assert.strictEqual(result.fragments.length, 5);
-    assert.strictEqual(result.totalduration, 45);
-    assert.strictEqual(result.fragments[0].cc, 20);
-    assert.strictEqual(result.fragments[2].cc, 20);
-    assert.strictEqual(result.fragments[3].cc, 21); //continuity counter should increase around discontinuity
+    new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 5);
+        assert.strictEqual(result.totalduration, 45);
+        assert.strictEqual(result.fragments[0].cc, 20);
+        assert.strictEqual(result.fragments[2].cc, 20);
+        assert.strictEqual(result.fragments[3].cc, 21); //continuity counter should increase around discontinuity
+        done();
+      })
+      .catch(done);
   });
 
   it('parses manifest with one audio track', () => {
     var manifest = `#EXTM3U
 #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="600k",LANGUAGE="eng",NAME="Audio",AUTOSELECT=YES,DEFAULT=YES,URI="/videos/ZakEbrahim_2014/audio/600k.m3u8?qr=true&preroll=Blank",BANDWIDTH=614400`;
     var result = new PlaylistLoader({on : function() { }}).parseMasterPlaylistMedia(manifest, 'https://hls.ted.com/', 'AUDIO');
-    assert.strictEqual(result.length,1);
-    assert.strictEqual(result[0]['autoselect'],true);
-    assert.strictEqual(result[0]['default'],true);
-    assert.strictEqual(result[0]['forced'],false);
-    assert.strictEqual(result[0]['groupId'],'600k');
-    assert.strictEqual(result[0]['lang'],'eng');
-    assert.strictEqual(result[0]['name'],'Audio');
-    assert.strictEqual(result[0]['url'],'https://hls.ted.com/videos/ZakEbrahim_2014/audio/600k.m3u8?qr=true&preroll=Blank');
+      assert.strictEqual(result.length,1);
+      assert.strictEqual(result[0]['autoselect'],true);
+      assert.strictEqual(result[0]['default'],true);
+      assert.strictEqual(result[0]['forced'],false);
+      assert.strictEqual(result[0]['groupId'],'600k');
+      assert.strictEqual(result[0]['lang'],'eng');
+      assert.strictEqual(result[0]['name'],'Audio');
+      assert.strictEqual(result[0]['url'],'https://hls.ted.com/videos/ZakEbrahim_2014/audio/600k.m3u8?qr=true&preroll=Blank');
   });
   //issue #425 - first fragment has null url and no decryptdata if EXT-X-KEY follows EXTINF
-  it('parse level with #EXT-X-KEY after #EXTINF', () => {
+  it('parse level with #EXT-X-KEY after #EXTINF', (done) => {
     var level = `#EXTM3U
 #EXT-X-TARGETDURATION:10
 #EXT-X-VERSION:3
@@ -468,34 +507,38 @@ lo007ts`;
 0007.ts
 #EXTINF:10,
 0008.ts`;
-    var result = new PlaylistLoader({on: function () { }}).parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8', 0);
-    assert.strictEqual(result.fragments.length, 8);
-    assert.strictEqual(result.totalduration, 80);
+    new PlaylistLoader({on: function () { }})
+      .parseLevelPlaylist(level, 'http://dummy.com/playlist.m3u8', 0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 8);
+        assert.strictEqual(result.totalduration, 80);
 
-    var fragdecryptdata, decryptdata = result.fragments[0].decryptdata, sn = 0;
+        var fragdecryptdata, decryptdata = result.fragments[0].decryptdata, sn = 0;
 
-    result.fragments.forEach(function (fragment, idx) {
-      sn = idx + 1;
+        result.fragments.forEach(function (fragment, idx) {
+          sn = idx + 1;
 
-      assert.strictEqual(fragment.url, 'http://dummy.com/000' + sn + '.ts');
+          assert.strictEqual(fragment.url, 'http://dummy.com/000' + sn + '.ts');
 
-      //decryptdata should persist across all fragments
-      fragdecryptdata = fragment.decryptdata;
-      assert.strictEqual(fragdecryptdata.method, decryptdata.method);
-      assert.strictEqual(fragdecryptdata.uri, decryptdata.uri);
-      assert.strictEqual(fragdecryptdata.key, decryptdata.key);
+          //decryptdata should persist across all fragments
+          fragdecryptdata = fragment.decryptdata;
+          assert.strictEqual(fragdecryptdata.method, decryptdata.method);
+          assert.strictEqual(fragdecryptdata.uri, decryptdata.uri);
+          assert.strictEqual(fragdecryptdata.key, decryptdata.key);
 
-      //initialization vector is correctly generated since it wasn't declared in the playlist
-      var iv = fragdecryptdata.iv;
-      assert.strictEqual(iv[15], idx);
+          //initialization vector is correctly generated since it wasn't declared in the playlist
+          var iv = fragdecryptdata.iv;
+          assert.strictEqual(iv[15], idx);
 
-      //hold this decrypt data to compare to the next fragment's decrypt data
-      decryptdata = fragment.decryptdata;
-    });
+          //hold this decrypt data to compare to the next fragment's decrypt data
+          decryptdata = fragment.decryptdata;
+        });
+        done();
+      }).catch(done);
   });
 
   //PR #454 - Add support for custom tags in fragment object
-  it('return custom tags in fragment object', () => {
+  it('return custom tags in fragment object', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-TARGETDURATION:10
@@ -522,22 +565,26 @@ http://dummy.url.com/hls/live/segment/segment_022916_164500865_719933.ts
 http://dummy.url.com/hls/live/segment/segment_022916_164500865_719934.ts
 #EXTINF:9.25,
 http://dummy.url.com/hls/live/segment/segment_022916_164500865_719935.ts`;
-    var result = new PlaylistLoader({on: function () { }}).parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0);
-    assert.strictEqual(result.fragments.length, 10);
-    assert.strictEqual(result.totalduration, 84.94);
-    assert.strictEqual(result.targetduration, 10);
-    assert.strictEqual(result.fragments[0].url, 'http://dummy.url.com/hls/live/segment/segment_022916_164500865_719926.ts');
-    assert.strictEqual(result.fragments[0].tagList.length,1);
-    assert.strictEqual(result.fragments[2].tagList[0][0],'EXT-X-CUE-OUT');
-    assert.strictEqual(result.fragments[2].tagList[0][1],'DURATION=150,BREAKID=0x0');
-    assert.strictEqual(result.fragments[3].tagList[0][1],'0.50');
-    assert.strictEqual(result.fragments[4].tagList.length,2);
-    assert.strictEqual(result.fragments[4].tagList[0][0],'EXT-X-CUE-IN');
-    assert.strictEqual(result.fragments[7].tagList[0][0],'INF');
-    assert.strictEqual(result.fragments[8].url, 'http://dummy.url.com/hls/live/segment/segment_022916_164500865_719934.ts');
+    new PlaylistLoader({on: function () { }})
+      .parseLevelPlaylist(level, 'http://dummy.url.com/playlist.m3u8', 0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 10);
+        assert.strictEqual(result.totalduration, 84.94);
+        assert.strictEqual(result.targetduration, 10);
+        assert.strictEqual(result.fragments[0].url, 'http://dummy.url.com/hls/live/segment/segment_022916_164500865_719926.ts');
+        assert.strictEqual(result.fragments[0].tagList.length,1);
+        assert.strictEqual(result.fragments[2].tagList[0][0],'EXT-X-CUE-OUT');
+        assert.strictEqual(result.fragments[2].tagList[0][1],'DURATION=150,BREAKID=0x0');
+        assert.strictEqual(result.fragments[3].tagList[0][1],'0.50');
+        assert.strictEqual(result.fragments[4].tagList.length,2);
+        assert.strictEqual(result.fragments[4].tagList[0][0],'EXT-X-CUE-IN');
+        assert.strictEqual(result.fragments[7].tagList[0][0],'INF');
+        assert.strictEqual(result.fragments[8].url, 'http://dummy.url.com/hls/live/segment/segment_022916_164500865_719934.ts');
+        done();
+      }).catch(done);
   });
 
-  it('parses playlists with #EXT-X-PROGRAM-DATE-TIME after #EXTINF before fragment URL', () => {
+  it('parses playlists with #EXT-X-PROGRAM-DATE-TIME after #EXTINF before fragment URL', (done) => {
     var level = `#EXTM3U
 #EXT-X-VERSION:2
 #EXT-X-TARGETDURATION:10
@@ -552,20 +599,24 @@ Rollover38803/20160525T064049-01-69844068.ts
 #EXT-X-PROGRAM-DATE-TIME:2016-05-27T16:35:04Z
 Rollover38803/20160525T064049-01-69844069.ts
     `;
-    var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8',0);
-    assert.strictEqual(result.fragments.length, 3);
-    assert.strictEqual(result.totalduration, 30);
-    assert.strictEqual(result.fragments[0].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844067.ts');
-    assert.strictEqual(result.fragments[0].programDateTime.getTime(), 1464366884000);
-    assert.strictEqual(result.fragments[1].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844068.ts');
-    assert.strictEqual(result.fragments[1].programDateTime.getTime(), 1464366894000);
-    assert.strictEqual(result.fragments[2].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844069.ts');
-    assert.strictEqual(result.fragments[2].programDateTime.getTime(), 1464366904000);
+    new PlaylistLoader({on : function() { }})
+      .parseLevelPlaylist(level, 'http://video.example.com/disc.m3u8',0)
+      .then(result => {
+        assert.strictEqual(result.fragments.length, 3);
+        assert.strictEqual(result.totalduration, 30);
+        assert.strictEqual(result.fragments[0].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844067.ts');
+        assert.strictEqual(result.fragments[0].programDateTime.getTime(), 1464366884000);
+        assert.strictEqual(result.fragments[1].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844068.ts');
+        assert.strictEqual(result.fragments[1].programDateTime.getTime(), 1464366894000);
+        assert.strictEqual(result.fragments[2].url, 'http://video.example.com/Rollover38803/20160525T064049-01-69844069.ts');
+        assert.strictEqual(result.fragments[2].programDateTime.getTime(), 1464366904000);
+        done();
+      }).catch(done);
   });
 });
 
 
-it('parses #EXTINF without a leading digit', () => {
+it('parses #EXTINF without a leading digit', (done) => {
   var level = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-PLAYLIST-TYPE:VOD
@@ -573,7 +624,11 @@ it('parses #EXTINF without a leading digit', () => {
 #EXTINF:.360,
 /sec(3ae40f708f79ca9471f52b86da76a3a8)/frag(1)/video/107/282/158282701_mp4_h264_aac_hq.ts
 #EXT-X-ENDLIST`;
-  var result = new PlaylistLoader({on : function() { }}).parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0);
-  assert.strictEqual(result.fragments.length, 1);
-  assert.strictEqual(result.fragments[0].duration, 0.360);
+  var result = new PlaylistLoader({on : function() { }})
+    .parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core',0)
+    .then(result => {
+      assert.strictEqual(result.fragments.length, 1);
+      assert.strictEqual(result.fragments[0].duration, 0.360);
+      done();
+    }).catch(done);
 });


### PR DESCRIPTION
This yields during level playlist parsing.

The tests are slower since the requestIdleCallback shim on node uses throttling. Should not affect browser code.