### PR TITLE
Further optimize playlist parsing

### DIFF
--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -12,7 +12,7 @@ import {logger} from '../utils/logger';
 // https://regex101.com is your friend
 const MASTER_PLAYLIST_REGEX = /#EXT-X-STREAM-INF:([^\n\r]*)[\r\n]+([^\r\n]+)/g;
 const MASTER_PLAYLIST_MEDIA_REGEX = /#EXT-X-MEDIA:(.*)/g;
-const LEVEL_PLAYLIST_REGEX_FAST = /#EXTINF: *([^,]+),?(.*)|(?!#)(\S.+)|#EXT-X-BYTERANGE: *(.+)|#EXT-X-PROGRAM-DATE-TIME:(.+)|#.*/g;
+const LEVEL_PLAYLIST_REGEX_FAST = /(?!#)(.+)|#EXT(?:INF: *([^,]+),?(.*)|-X-BYTERANGE: *(.+)|-X-PROGRAM-DATE-TIME:(.+))|#.*/g;
 const LEVEL_PLAYLIST_REGEX_SLOW = /(?:(?:#(EXTM3U))|(?:#EXT-X-(PLAYLIST-TYPE):(.+))|(?:#EXT-X-(MEDIA-SEQUENCE): *(\d+))|(?:#EXT-X-(TARGETDURATION): *(\d+))|(?:#EXT-X-(KEY):(.+))|(?:#EXT-X-(START):(.+))|(?:#EXT-X-(ENDLIST))|(?:#EXT-X-(DISCONTINUITY-SEQ)UENCE:(\d+))|(?:#EXT-X-(DIS)CONTINUITY))|(?:#EXT-X-(VERSION):(\d+))|(?:(#)(.*):(.*))|(?:(#)(.*))(?:.*)\r?\n?/;
 
 class LevelKey {
@@ -295,15 +295,7 @@ class PlaylistLoader extends EventHandler {
     LEVEL_PLAYLIST_REGEX_FAST.lastIndex = 0;
 
     while ((result = LEVEL_PLAYLIST_REGEX_FAST.exec(string)) !== null) {
-      if (result[1]) { // INF
-        const duration = result[1];
-        frag.duration = parseFloat(duration);
-        const title = result[2];
-        frag.title = title ? title : null;
-        if (this.createTagList) {
-          frag.tagList.push(title ? [ 'INF',duration,title ] : [ 'INF',duration ]);
-        }
-      } else if (result[3]) { // url
+      if (result[1]) { // url
         if (!isNaN(frag.duration)) {
           const sn = currentSN++;
           frag.type = type;
@@ -314,7 +306,7 @@ class PlaylistLoader extends EventHandler {
           frag.level = id;
           frag.cc = cc;
           frag.baseurl = baseurl;
-          frag.relurl = result[3];
+          frag.relurl = result[1];
 
           level.fragments.push(frag);
           prevFrag = frag;
@@ -324,6 +316,14 @@ class PlaylistLoader extends EventHandler {
           if (this.createTagList) {
             frag.tagList = [];
           }
+        }
+      } else if (result[2]) { // INF
+        const duration = result[2];
+        frag.duration = parseFloat(duration);
+        const title = result[3];
+        frag.title = title ? title : null;
+        if (this.createTagList) {
+          frag.tagList.push(title ? [ 'INF',duration,title ] : [ 'INF',duration ]);
         }
       } else if (result[4]) { // X-BYTERANGE
         frag.rawByteRange = result[4];

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -286,9 +286,10 @@ class PlaylistLoader extends EventHandler {
         prevFrag = null,
         frag = new Fragment(),
         result,
+        createTagList = this.createTagList,
         i;
 
-    if (this.createTagList) {
+    if (createTagList) {
       frag.tagList = [];
     }
 
@@ -313,7 +314,7 @@ class PlaylistLoader extends EventHandler {
           totalduration += frag.duration;
 
           frag = new Fragment();
-          if (this.createTagList) {
+          if (createTagList) {
             frag.tagList = [];
           }
         }
@@ -322,14 +323,14 @@ class PlaylistLoader extends EventHandler {
         frag.duration = parseFloat(duration);
         const title = result[2];
         frag.title = title ? title : null;
-        if (this.createTagList) {
+        if (createTagList) {
           frag.tagList.push(title ? [ 'INF',duration,title ] : [ 'INF',duration ]);
         }
       } else if (result[3]) { // X-BYTERANGE
         frag.rawByteRange = result[3];
       } else if (result[4]) { // PROGRAM-DATE-TIME
         frag.rawProgramDateTime = result[4];
-        if (this.createTagList) {
+        if (createTagList) {
           frag.tagList.push(['PROGRAM-DATE-TIME', result[4]]);
         }
       } else {
@@ -345,7 +346,7 @@ class PlaylistLoader extends EventHandler {
 
         switch (result[i]) {
           case '#':
-            if (this.createTagList) {
+            if (createTagList) {
               frag.tagList.push(value2 ? [ value1,value2 ] : [ value1 ]);
             }
             break;
@@ -368,7 +369,7 @@ class PlaylistLoader extends EventHandler {
             break;
           case 'DIS':
             cc++;
-            if (this.createTagList) {
+            if (createTagList) {
               frag.tagList.push(['DIS']);
             }
             break;

--- a/src/loader/playlist-loader.js
+++ b/src/loader/playlist-loader.js
@@ -296,7 +296,22 @@ class PlaylistLoader extends EventHandler {
     LEVEL_PLAYLIST_REGEX_FAST.lastIndex = 0;
 
     while ((result = LEVEL_PLAYLIST_REGEX_FAST.exec(string)) !== null) {
-      if (result[5]) { // url
+      if (result[1]) { // INF
+        const duration = result[1];
+        frag.duration = parseFloat(duration);
+        const title = result[2];
+        frag.title = title ? title : null;
+        if (createTagList) {
+          frag.tagList.push(title ? [ 'INF',duration,title ] : [ 'INF',duration ]);
+        }
+      } else if (result[3]) { // X-BYTERANGE
+        frag.rawByteRange = result[3];
+      } else if (result[4]) { // PROGRAM-DATE-TIME
+        frag.rawProgramDateTime = result[4];
+        if (createTagList) {
+          frag.tagList.push(['PROGRAM-DATE-TIME', result[4]]);
+        }
+      } else if (result[5]) { // url
         if (!isNaN(frag.duration)) {
           const sn = currentSN++;
           frag.type = type;
@@ -317,21 +332,6 @@ class PlaylistLoader extends EventHandler {
           if (createTagList) {
             frag.tagList = [];
           }
-        }
-      } else if (result[1]) { // INF
-        const duration = result[1];
-        frag.duration = parseFloat(duration);
-        const title = result[2];
-        frag.title = title ? title : null;
-        if (createTagList) {
-          frag.tagList.push(title ? [ 'INF',duration,title ] : [ 'INF',duration ]);
-        }
-      } else if (result[3]) { // X-BYTERANGE
-        frag.rawByteRange = result[3];
-      } else if (result[4]) { // PROGRAM-DATE-TIME
-        frag.rawProgramDateTime = result[4];
-        if (createTagList) {
-          frag.tagList.push(['PROGRAM-DATE-TIME', result[4]]);
         }
       } else {
         result = result[0].match(LEVEL_PLAYLIST_REGEX_SLOW);


### PR DESCRIPTION
This gives an additional 16% speed increase relative to master (#878) by:

- Optimizing the regex so the regex engine never needs to backtrack on the hot path.
- Making `tagList` optional with the `createTagList` option (defaults to `true`).