### PR TITLE
Whe loading a fragment with missing frames, backtrack a segment to find the keyframe

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -400,28 +400,42 @@ class StreamController extends EventHandler {
     }
     if (foundFrag) {
       frag = foundFrag;
-      start = foundFrag.start;
+      const curSNIdx = frag.sn - levelDetails.startSN;
+      const sameLevel = fragPrevious && frag.level === fragPrevious.level;
       //logger.log('find SN matching with pos:' +  bufferEnd + ':' + frag.sn);
-      if (fragPrevious && frag.level === fragPrevious.level && frag.sn === fragPrevious.sn) {
-        if (frag.sn < levelDetails.endSN) {
-          let deltaPTS = fragPrevious.deltaPTS,
-          curSNIdx = frag.sn - levelDetails.startSN;
-          // if there is a significant delta between audio and video, larger than max allowed hole,
-          // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
-          // let's try to load previous fragment again to get last keyframe
-          // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
-          if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
-            frag = fragments[curSNIdx-1];
-            logger.warn(`SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this`);
-            // decrement previous frag load counter to avoid frag loop loading error when next fragment will get reloaded
-            fragPrevious.loadCounter--;
+       if (sameLevel && frag.sn === fragPrevious.sn) {
+          if (frag.sn < levelDetails.endSN) {
+            let deltaPTS = fragPrevious.deltaPTS;
+            // if there is a significant delta between audio and video, larger than max allowed hole,
+            // and if previous remuxed fragment did not start with a keyframe. (fragPrevious.dropped)
+            // let's try to load previous fragment again to get last keyframe
+            // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
+            if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
+              frag = fragments[curSNIdx - 1];
+              logger.warn(`SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this`);
+              // decrement previous frag load counter to avoid frag loop loading error when next fragment will get reloaded
+              fragPrevious.loadCounter--;
+            } else {
+              frag = fragments[curSNIdx + 1];
+              logger.log(`SN just loaded, load next one: ${frag.sn}`);
+            }
           } else {
-            frag = fragments[curSNIdx+1];
-            logger.log(`SN just loaded, load next one: ${frag.sn}`);
+            frag = null;
           }
-        } else {
-          frag = null;
-        }
+        } else if (frag.dropped && !sameLevel) {
+         // If a fragment has dropped frames and it's in a different level/sequence, load the previous fragment to try and find the keyframe
+         // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
+         logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find a keyframe');
+         frag.dropped = 0;
+         if (curSNIdx) {
+           const prev = fragments[curSNIdx - 1];
+           if (prev.loadCounter) {
+             prev.loadCounter--;
+           }
+           frag = prev;
+         } else {
+           frag = null;
+         }
       }
     }
     return frag;
@@ -707,6 +721,7 @@ class StreamController extends EventHandler {
           if(level.details) {
             level.details.fragments.forEach(fragment => {
               fragment.loadCounter = undefined;
+              fragment.backtracked = undefined;
             });
           }
       });
@@ -1058,15 +1073,33 @@ class StreamController extends EventHandler {
 
       logger.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
+      // Detect gaps in a fragment  and try to fix it by finding a keyframe in the previous fragment (see _findFragments)
+      if(data.type === 'video') {
+        frag.dropped = data.dropped;
+        if (frag.dropped) {
+          if (!frag.backtracked) {
+            // Return back to the IDLE state without appending to buffer
+            // Causes findFragments to backtrack a segment and find the keyframe
+            // Audio fragments arriving before video sets the nextLoadPosition, causing _findFragments to skip the backtracked fragment
+            frag.backtracked = true;
+            this.nextLoadPosition = frag.startPTS;
+            this.state = State.IDLE;
+            this.tick();
+            return;
+          } else {
+            logger.warn('Already backtracked on this fragment, appending with the gap');
+          }
+        } else {
+          // Only reset the backtracked flag if we've loaded the frag without any dropped frames
+          frag.backtracked = false;
+        }
+      }
+
       var drift = LevelHelper.updateFragPTSDTS(level.details,frag.sn,data.startPTS,data.endPTS,data.startDTS,data.endDTS),
           hls = this.hls;
       hls.trigger(Event.LEVEL_PTS_UPDATED, {details: level.details, level: this.level, drift: drift, type: data.type, start: data.startPTS, end: data.endPTS});
 
       // has remuxer dropped video frames located before first keyframe ?
-      if(data.type === 'video') {
-        frag.dropped = data.dropped;
-      }
-
       [data.data1, data.data2].forEach(buffer => {
         if (buffer) {
           this.appended = true;

--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -402,6 +402,8 @@ class StreamController extends EventHandler {
       frag = foundFrag;
       const curSNIdx = frag.sn - levelDetails.startSN;
       const sameLevel = fragPrevious && frag.level === fragPrevious.level;
+      const prevFrag = fragments[curSNIdx - 1];
+      const nextFrag = fragments[curSNIdx + 1];
       //logger.log('find SN matching with pos:' +  bufferEnd + ':' + frag.sn);
        if (sameLevel && frag.sn === fragPrevious.sn) {
           if (frag.sn < levelDetails.endSN) {
@@ -411,32 +413,35 @@ class StreamController extends EventHandler {
             // let's try to load previous fragment again to get last keyframe
             // then we will reload again current fragment (that way we should be able to fill the buffer hole ...)
             if (deltaPTS && deltaPTS > config.maxBufferHole && fragPrevious.dropped && curSNIdx) {
-              frag = fragments[curSNIdx - 1];
+              frag = prevFrag;
               logger.warn(`SN just loaded, with large PTS gap between audio and video, maybe frag is not starting with a keyframe ? load previous one to try to overcome this`);
               // decrement previous frag load counter to avoid frag loop loading error when next fragment will get reloaded
               fragPrevious.loadCounter--;
             } else {
-              frag = fragments[curSNIdx + 1];
+              frag = nextFrag;
               logger.log(`SN just loaded, load next one: ${frag.sn}`);
             }
           } else {
             frag = null;
           }
         } else if (frag.dropped && !sameLevel) {
-         // If a fragment has dropped frames and it's in a different level/sequence, load the previous fragment to try and find the keyframe
-         // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
-         logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find a keyframe');
-         frag.dropped = 0;
-         if (curSNIdx) {
-           const prev = fragments[curSNIdx - 1];
-           if (prev.loadCounter) {
-             prev.loadCounter--;
-           }
-           frag = prev;
+         // Only backtrack a max of 1 consecutive fragment to prevent sliding back too far when little or no frags start with keyframes
+         if (nextFrag && nextFrag.backtracked) {
+           logger.warn(`Already backtracked from fragment ${curSNIdx + 1}, will not backtrack to fragment ${curSNIdx}. Loading fragment ${curSNIdx + 1}`);
+           frag = nextFrag;
          } else {
-           frag = null;
+           // If a fragment has dropped frames and it's in a different level/sequence, load the previous fragment to try and find the keyframe
+           // Reset the dropped count now since it won't be reset until we parse the fragment again, which prevents infinite backtracking on the same segment
+           logger.warn('Loaded fragment with dropped frames, backtracking 1 segment to find a keyframe');
+           frag.dropped = 0;
+           if (prevFrag && prevFrag.loadCounter) {
+             prevFrag.loadCounter--;
+             frag = prevFrag;
+           } else {
+             frag = null;
+           }
          }
-      }
+       }
     }
     return frag;
   }


### PR DESCRIPTION
Previously, backtracking would only occur under specific circumstances, leading to small gaps streams whose fragments don't always start with keyframes but are otherwise fine. This PR changes the stream-controller such that we always backtrack (load the previous fragment) when encountering a dropped frame. 

#855 

I'm having trouble reproducing this (even in 0.6.12) - can I have help verifying? Maybe this isn't needed anymore.

https://content.jwplatform.com/manifests/BHbQYVup.m3u8
