### PR TITLE
add method to retrieve videoElement from hls instance w/updated API doc

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -742,6 +742,12 @@ Calling this method will:
  - signal the end of the stream on MediaSource
  - reset video source (`video.src = ''`)
 
+ #### `hls.retrieveMedia()`
+
+Calling this method will:
+
+ - return the bound videoElement from the hls instance
+
 ## Quality switch Control API
 
 By default, hls.js handles quality switch automatically, using heuristics based on fragment loading bitrate and quality level bandwidth exposed in the variant manifest.

--- a/src/hls.js
+++ b/src/hls.js
@@ -210,6 +210,11 @@ class Hls {
     this.media = null;
   }
 
+  retrieveMedia() {
+    logger.log('retrieveMedia');
+    return this.media;
+  }
+
   loadSource(url) {
     logger.log(`loadSource:${url}`);
     this.url = url;


### PR DESCRIPTION
### Description of the Changes

Simple addition to retrieve videoElement from hls instance, without the need to access the property directly (future-proofing). 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
