### PR TITLE
add Fragment object in all events fired by demuxer

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -1016,12 +1016,16 @@ Full list of Events is available below:
     -  data: { frag : fragment object }
   - `Hls.Events.KEY_LOADED`  - fired when a decryption key loading is completed
     -  data: { frag : fragment object }
+  - `Hls.Events.INIT_PTS_FOUND`  - fired when first timestamp has been found
+    -  data: { id : demuxer id, frag : fragment object, initPTS: initPTS }
   - `Hls.Events.FRAG_LOADING`  - fired when a fragment loading starts
     -  data: { frag : fragment object }
   - `Hls.Events.FRAG_LOAD_PROGRESS`  - fired when a fragment load is in progress
     - data: { frag : fragment object with frag.loaded=stats.loaded, stats : { trequest, tfirst, loaded, total } }
   - `Hls.Events.FRAG_LOADED`  - fired when a fragment loading is completed
     -  data: { frag : fragment object, payload : fragment payload, stats : { trequest, tfirst, tload, length}}
+  - `Hls.Events.FRAG_DECRYPTED`  - fired when a fragment decryption is completed
+    -  data: { id : demuxer id, frag : fragment object, stats : { tstart, tdecrypt}}
   - `Hls.Events.FRAG_PARSING_INIT_SEGMENT` - fired when Init Segment has been extracted from fragment
     -  data: { id: demuxer id, frag : fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment}
   - `Hls.Events.FRAG_PARSING_METADATA`  - fired when parsing id3 is completed

--- a/doc/API.md
+++ b/doc/API.md
@@ -1023,13 +1023,13 @@ Full list of Events is available below:
   - `Hls.Events.FRAG_LOADED`  - fired when a fragment loading is completed
     -  data: { frag : fragment object, payload : fragment payload, stats : { trequest, tfirst, tload, length}}
   - `Hls.Events.FRAG_PARSING_INIT_SEGMENT` - fired when Init Segment has been extracted from fragment
-    -  data: { id: demuxer id, moov : moov MP4 box, codecs : codecs found while parsing fragment}
+    -  data: { id: demuxer id, frag : fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment}
   - `Hls.Events.FRAG_PARSING_METADATA`  - fired when parsing id3 is completed
-      -  data: { id: demuxer id, samples : [ id3 pes - pts and dts timestamp are relative, values are in seconds]}
+      -  data: { id: demuxer id, frag : fragment object, samples : [ id3 pes - pts and dts timestamp are relative, values are in seconds]}
   - `Hls.Events.FRAG_PARSING_DATA`  - fired when moof/mdat have been extracted from fragment
-    -  data: { id: demuxer id, moof : moof MP4 box, mdat : mdat MP4 box, startPTS : PTS of first sample, endPTS : PTS of last sample, startDTS : DTS of first sample, endDTS : DTS of last sample, type : stream type (audio or video), nb : number of samples}
+    -  data: { id: demuxer id, frag : fragment object, moof : moof MP4 box, mdat : mdat MP4 box, startPTS : PTS of first sample, endPTS : PTS of last sample, startDTS : DTS of first sample, endDTS : DTS of last sample, type : stream type (audio or video), nb : number of samples}
   - `Hls.Events.FRAG_PARSED`  - fired when fragment parsing is completed
-    -  data: { id: demuxer id}
+    -  data: { id: demuxer id,frag : fragment object}
   - `Hls.Events.FRAG_BUFFERED`  - fired when fragment remuxed MP4 boxes have all been appended into SourceBuffer
     -  data: { id: demuxer id, frag : fragment object, stats : { trequest, tfirst, tload, tparsed, tbuffered, length} }
   - `Hls.Events.FRAG_CHANGED`  - fired when fragment matching with current video position is changing

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -600,11 +600,12 @@ class AudioStreamController extends EventHandler {
   }
 
   onFragParsingInitSegment(data) {
-    let fragCurrent = this.fragCurrent;
+    const fragCurrent = this.fragCurrent;
+    const fragNew = data.frag;
     if (fragCurrent &&
         data.id === 'audio' &&
-        data.sn === fragCurrent.sn &&
-        data.level === fragCurrent.level &&
+        fragNew.sn === fragCurrent.sn &&
+        fragNew.level === fragCurrent.level &&
         this.state === State.PARSING) {
       let tracks = data.tracks, track;
 
@@ -639,16 +640,16 @@ class AudioStreamController extends EventHandler {
   }
 
   onFragParsingData(data) {
-    let fragCurrent = this.fragCurrent;
+    const fragCurrent = this.fragCurrent;
+    const fragNew = data.frag;
     if (fragCurrent &&
         data.id === 'audio' &&
         data.type === 'audio' &&
-        data.sn === fragCurrent.sn &&
-        data.level === fragCurrent.level &&
+        fragNew.sn === fragCurrent.sn &&
+        fragNew.level === fragCurrent.level &&
         this.state === State.PARSING) {
       let trackId= this.trackId,
           track = this.tracks[trackId],
-          frag = this.fragCurrent,
           hls = this.hls;
 
       if (isNaN(data.endPTS)) {
@@ -657,7 +658,7 @@ class AudioStreamController extends EventHandler {
       }
 
       logger.log(`parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb}`);
-      LevelHelper.updateFragPTSDTS(track.details,frag.sn,data.startPTS,data.endPTS);
+      LevelHelper.updateFragPTSDTS(track.details,fragCurrent.sn,data.startPTS,data.endPTS);
 
       let audioSwitch = this.audioSwitch, media = this.media, appendOnBufferFlush = false;
       //Only flush audio from old audio tracks when PTS is known on new audio track
@@ -709,11 +710,12 @@ class AudioStreamController extends EventHandler {
   }
 
   onFragParsed(data) {
-    let fragCurrent = this.fragCurrent;
+    const fragCurrent = this.fragCurrent;
+    const fragNew = data.frag;
     if (fragCurrent &&
         data.id === 'audio' &&
-        data.sn === fragCurrent.sn &&
-        data.level === fragCurrent.level &&
+        fragNew.sn === fragCurrent.sn &&
+        fragNew.level === fragCurrent.level &&
         this.state === State.PARSING) {
       this.stats.tparsed = performance.now();
       this.state = State.PARSED;

--- a/src/controller/audio-stream-controller.js
+++ b/src/controller/audio-stream-controller.js
@@ -70,7 +70,7 @@ class AudioStreamController extends EventHandler {
 
   //Signal that video PTS was found
   onInitPtsFound(data) {
-    var demuxerId=data.id, cc = data.cc, initPTS = data.initPTS;
+    var demuxerId=data.id, cc = data.frag.cc, initPTS = data.initPTS;
     if(demuxerId === 'main') {
       //Always update the new INIT PTS
       //Can change due level switch
@@ -560,13 +560,12 @@ class AudioStreamController extends EventHandler {
         var track = this.tracks[this.trackId],
             details = track.details,
             duration = details.totalduration,
-            start = fragCurrent.start,
             trackId = fragCurrent.level,
             sn = fragCurrent.sn,
             cc = fragCurrent.cc,
             audioCodec = this.config.defaultAudioCodec || track.audioCodec || 'mp4a.40.2',
             stats = this.stats = data.stats;
-      if (fragLoaded.sn === 'initSegment') {
+      if (sn === 'initSegment') {
         this.state = State.IDLE;
 
         stats.tparsed = stats.tbuffered = performance.now();
@@ -589,7 +588,7 @@ class AudioStreamController extends EventHandler {
           logger.log(`Demuxing ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
           // time Offset is accurate if level PTS is known, or if playlist is not sliding (not live)
           let accurateTimeOffset = false; //details.PTSKnown || !details.live;
-          this.demuxer.push(data.payload, initSegmentData, audioCodec, null, start, cc, trackId, sn, duration, fragCurrent.decryptdata, accurateTimeOffset, initPTS);
+          this.demuxer.push(data.payload, initSegmentData, audioCodec, null, fragCurrent, duration, accurateTimeOffset, initPTS);
         } else {
           logger.log(`unknown video PTS for continuity counter ${cc}, waiting for video PTS before demuxing audio frag ${sn} of [${details.startSN} ,${details.endSN}],track ${trackId}`);
           this.waitingFragment=data;

--- a/src/demux/aacdemuxer.js
+++ b/src/demux/aacdemuxer.js
@@ -7,14 +7,13 @@ import ID3 from '../demux/id3';
 
  class AACDemuxer {
 
-  constructor(observer, id, remuxer, config) {
+  constructor(observer, remuxer, config) {
     this.observer = observer;
-    this.id = id;
     this.config = config;
     this.remuxer = remuxer;
   }
 
-  resetInitSegment(initSegment,level,sn,audioCodec,videoCodec, duration) {
+  resetInitSegment(initSegment,audioCodec,videoCodec, duration) {
     this._aacTrack = {container : 'audio/adts', type: 'audio', id :-1, sequenceNumber: 0, isAAC : true , samples : [], len : 0, manifestCodec : audioCodec, duration : duration};
   }
 
@@ -38,7 +37,7 @@ import ID3 from '../demux/id3';
 
 
   // feed incoming data to the front of the parsing pipeline
-  append(data, timeOffset, cc, level, sn, contiguous,accurateTimeOffset) {
+  append(data, timeOffset, contiguous,accurateTimeOffset) {
     var track,
         id3 = new ID3(data),
         pts = 90*id3.timeStamp,
@@ -91,7 +90,7 @@ import ID3 from '../demux/id3';
         break;
       }
     }
-    this.remuxer.remux(level, sn , cc, track,{samples : []}, {samples : [ { pts: pts, dts : pts, unit : id3.payload} ]}, { samples: [] }, timeOffset, contiguous,accurateTimeOffset);
+    this.remuxer.remux(track,{samples : []}, {samples : [ { pts: pts, dts : pts, unit : id3.payload} ]}, { samples: [] }, timeOffset, contiguous,accurateTimeOffset);
   }
 
   destroy() {

--- a/src/demux/demuxer-inline.js
+++ b/src/demux/demuxer-inline.js
@@ -4,7 +4,6 @@
 
 import Event from '../events';
 import {ErrorTypes, ErrorDetails} from '../errors';
-import {logger} from '../utils/logger';
 import Decrypter from '../crypt/decrypter';
 import AACDemuxer from '../demux/aacdemuxer';
 import MP4Demuxer from '../demux/mp4demuxer';
@@ -14,11 +13,10 @@ import PassThroughRemuxer from '../remux/passthrough-remuxer';
 
 class DemuxerInline {
 
-  constructor(hls,id, typeSupported, config=null) {
-    this.hls = hls;
-    this.id = id;
-    this.config = this.hls.config || config;
+  constructor(observer,typeSupported, config) {
+    this.observer = observer;
     this.typeSupported = typeSupported;
+    this.config = config;
   }
 
   destroy() {
@@ -28,10 +26,10 @@ class DemuxerInline {
     }
   }
 
-  push(data, initSegment, audioCodec, videoCodec, timeOffset, cc, level, sn, duration,decryptdata,accurateTimeOffset,defaultInitPTS) {
+  push(data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration,accurateTimeOffset,defaultInitPTS) {
     if ((data.byteLength > 0) && (decryptdata != null) && (decryptdata.key != null) && (decryptdata.method === 'AES-128')) {
       if (this.decrypter == null) {
-        this.decrypter = new Decrypter(this.hls, this.config);
+        this.decrypter = new Decrypter(this.observer, this.config);
       }
       var localthis = this;
       // performance.now() not available on WebWorker, at least on Safari Desktop
@@ -48,22 +46,21 @@ class DemuxerInline {
         } catch(error) {
           endTime = Date.now();
         }
-        localthis.hls.trigger(Event.FRAG_DECRYPTED, { level : level, sn : sn, stats: { tstart: startTime, tdecrypt: endTime } });
-        localthis.pushDecrypted(new Uint8Array(decryptedData), new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, cc, level, sn, duration, accurateTimeOffset,defaultInitPTS);
+        localthis.observer.trigger(Event.FRAG_DECRYPTED, { stats: { tstart: startTime, tdecrypt: endTime } });
+        localthis.pushDecrypted(new Uint8Array(decryptedData), new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset,defaultInitPTS);
       });
     } else {
-      this.pushDecrypted(new Uint8Array(data), new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, cc, level, sn, duration,accurateTimeOffset,defaultInitPTS);
+      this.pushDecrypted(new Uint8Array(data), new Uint8Array(initSegment), audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration,accurateTimeOffset,defaultInitPTS);
     }
   }
 
-  pushDecrypted(data, initSegment, audioCodec, videoCodec, timeOffset, cc, level, sn, duration,accurateTimeOffset,defaultInitPTS) {
+  pushDecrypted(data, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration,accurateTimeOffset,defaultInitPTS) {
     var demuxer = this.demuxer;
-    const id = this.id;
     if (!demuxer || 
        // in case of continuity change, we might switch from content type (AAC container to TS container for example)
        // so let's check that current demuxer is still valid
-        (cc !== this.cc && !this.probe(data))) {
-      const hls = this.hls;
+        (discontinuity && !this.probe(data))) {
+      const observer = this.observer;
       const muxConfig = [ {demux : TSDemuxer,  remux : MP4Remuxer},
                           {demux : AACDemuxer, remux : MP4Remuxer},
                           {demux : MP4Demuxer, remux : PassThroughRemuxer}];
@@ -73,40 +70,29 @@ class DemuxerInline {
         const mux = muxConfig[i];
         const probe = mux.demux.probe;
         if(probe(data)) {
-          const remuxer = this.remuxer = new mux.remux(hls,id,this.config,this.typeSupported);
-          demuxer = new mux.demux(hls,id,remuxer,this.config,this.typeSupported);
+          const remuxer = this.remuxer = new mux.remux(observer,this.config,this.typeSupported);
+          demuxer = new mux.demux(observer,remuxer,this.config,this.typeSupported);
           this.probe = probe;
           break;
         }
       }
       if(!demuxer) {
-        hls.trigger(Event.ERROR, {type : ErrorTypes.MEDIA_ERROR, id : id, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: 'no demux matching with content found'});
+        observer.trigger(Event.ERROR, {type : ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: true, reason: 'no demux matching with content found'});
         return;
       }
       this.demuxer = demuxer;
-      this.lastCC = 0;
     }
-    let contiguous = false;
     const remuxer = this.remuxer;
-    if (cc !== this.lastCC) {
-      logger.log(`${id}:discontinuity detected`);
-      demuxer.resetInitSegment(initSegment,level,sn,audioCodec,videoCodec,duration);
+
+    if (discontinuity || trackSwitch) {
+      demuxer.resetInitSegment(initSegment,audioCodec,videoCodec,duration);
       remuxer.resetInitSegment();
+    }
+    if (discontinuity) {
       demuxer.resetTimeStamp();
       remuxer.resetTimeStamp(defaultInitPTS);
-      this.lastCC = cc;
     }
-    if (level !== this.lastLevel) {
-      logger.log(`${id}:switch detected`);
-      demuxer.resetInitSegment(initSegment,level,sn,audioCodec,videoCodec,duration);
-      remuxer.resetInitSegment();
-      this.lastLevel = level;
-    } else if (sn === (this.lastSN+1)) {
-      contiguous = true;
-    }
-    this.lastSN = sn;
-    this.cc = cc;
-    demuxer.append(data,timeOffset,cc,level,sn,contiguous,accurateTimeOffset);
+    demuxer.append(data,timeOffset,contiguous,accurateTimeOffset);
   }
 }
 

--- a/src/demux/demuxer-worker.js
+++ b/src/demux/demuxer-worker.js
@@ -39,7 +39,7 @@ var DemuxerWorker = function (self) {
         forwardMessage('init',null);
         break;
       case 'demux':
-        self.demuxer.push(data.data, data.initSegment, data.audioCodec, data.videoCodec, data.timeOffset, data.cc, data.level, data.sn, data.duration,data.decryptdata,data.accurateTimeOffset,data.defaultInitPTS);
+        self.demuxer.push(data.data, data.decryptdata, data.initSegment, data.audioCodec, data.videoCodec, data.timeOffset, data.cc, data.level, data.sn, data.duration,data.accurateTimeOffset,data.defaultInitPTS);
         break;
       default:
         break;

--- a/src/demux/demuxer-worker.js
+++ b/src/demux/demuxer-worker.js
@@ -29,7 +29,7 @@ var DemuxerWorker = function (self) {
     switch (data.cmd) {
       case 'init':
         let config = JSON.parse(data.config);
-        self.demuxer = new DemuxerInline(observer, data.id, data.typeSupported, config);
+        self.demuxer = new DemuxerInline(observer, data.typeSupported, config);
         try {
           enableLogs(config.debug === true);
         } catch(err) {

--- a/src/demux/demuxer-worker.js
+++ b/src/demux/demuxer-worker.js
@@ -39,7 +39,7 @@ var DemuxerWorker = function (self) {
         forwardMessage('init',null);
         break;
       case 'demux':
-        self.demuxer.push(data.data, data.decryptdata, data.initSegment, data.audioCodec, data.videoCodec, data.timeOffset, data.cc, data.level, data.sn, data.duration,data.accurateTimeOffset,data.defaultInitPTS);
+        self.demuxer.push(data.data, data.decryptdata, data.initSegment, data.audioCodec, data.videoCodec, data.timeOffset,data.discontinuity, data.trackSwitch,data.contiguous,data.duration,data.accurateTimeOffset,data.defaultInitPTS);
         break;
       default:
         break;

--- a/src/demux/demuxer.js
+++ b/src/demux/demuxer.js
@@ -3,18 +3,47 @@ import DemuxerInline from '../demux/demuxer-inline';
 import DemuxerWorker from '../demux/demuxer-worker';
 import {logger} from '../utils/logger';
 import {ErrorTypes, ErrorDetails} from '../errors';
+import EventEmitter from 'events';
 
 class Demuxer {
 
   constructor(hls, id) {
     this.hls = hls;
     this.id = id;
+    // observer setup
+    const observer = this.observer = new EventEmitter();
+    const config = hls.config;
+    observer.trigger = function trigger (event, ...data) {
+      observer.emit(event, event, ...data);
+    };
+
+    observer.off = function off (event, ...data) {
+      observer.removeListener(event, ...data);
+    };
+
+    var forwardMessage = function(ev,data) {
+      data = data || {};
+      data.frag = this.frag;
+      data.id = this.id;
+      hls.trigger(ev,data);
+    }.bind(this);
+
+    // forward events to main thread
+    observer.on(Event.FRAG_DECRYPTED, forwardMessage);
+    observer.on(Event.FRAG_PARSING_INIT_SEGMENT, forwardMessage);
+    observer.on(Event.FRAG_PARSING_DATA, forwardMessage);
+    observer.on(Event.FRAG_PARSED, forwardMessage);
+    observer.on(Event.ERROR, forwardMessage);
+    observer.on(Event.FRAG_PARSING_METADATA, forwardMessage);
+    observer.on(Event.FRAG_PARSING_USERDATA, forwardMessage);
+    observer.on(Event.INIT_PTS_FOUND, forwardMessage);
+
     var typeSupported = {
       mp4 : MediaSource.isTypeSupported('video/mp4'),
       mpeg: MediaSource.isTypeSupported('audio/mpeg'),
       mp3: MediaSource.isTypeSupported('audio/mp4; codecs="mp3"')
     };
-    if (hls.config.enableWorker && (typeof(Worker) !== 'undefined')) {
+    if (config.enableWorker && (typeof(Worker) !== 'undefined')) {
         logger.log('demuxing in webworker');
         let w;
         try {
@@ -23,18 +52,18 @@ class Demuxer {
           this.onwmsg = this.onWorkerMessage.bind(this);
           w.addEventListener('message', this.onwmsg);
           w.onerror = function(event) { hls.trigger(Event.ERROR, {type: ErrorTypes.OTHER_ERROR, details: ErrorDetails.INTERNAL_EXCEPTION, fatal: true, event : 'demuxerWorker', err : { message : event.message + ' (' + event.filename + ':' + event.lineno + ')' }});};
-          w.postMessage({cmd: 'init', typeSupported : typeSupported, id : id, config: JSON.stringify(hls.config)});
+          w.postMessage({cmd: 'init', typeSupported : typeSupported, id : id, config: JSON.stringify(config)});
         } catch(err) {
           logger.error('error while initializing DemuxerWorker, fallback on DemuxerInline');
           if (w) {
             // revoke the Object URL that was used to create demuxer worker, so as not to leak it
             URL.revokeObjectURL(w.objectURL);
           }
-          this.demuxer = new DemuxerInline(hls,id,typeSupported);
+          this.demuxer = new DemuxerInline(observer,id,typeSupported,config);
           this.w = undefined;
         }
       } else {
-        this.demuxer = new DemuxerInline(hls,id,typeSupported);
+        this.demuxer = new DemuxerInline(observer,id,typeSupported,config);
       }
   }
 
@@ -51,17 +80,36 @@ class Demuxer {
         this.demuxer = null;
       }
     }
+    let observer = this.observer;
+    if (observer) {
+      observer.removeAllListeners();
+      this.observer = null;
+    }
   }
 
-  push(data, initSegment, audioCodec, videoCodec, timeOffset, cc, level, sn, duration, decryptdata,accurateTimeOffset,defaultInitPTS) {
-    let w = this.w;
+  push(data, initSegment, audioCodec, videoCodec, frag, duration,accurateTimeOffset,defaultInitPTS) {
+    const w = this.w;
+    const timeOffset = !isNaN(frag.startDTS) ? frag.startDTS  : frag.start;
+    const decryptdata = frag.decryptdata;
+    const lastFrag = this.frag;
+    const discontinuity = !(lastFrag && (frag.cc === lastFrag.cc));
+    const trackSwitch = !(lastFrag && (frag.level === lastFrag.level));
+    const nextSN = lastFrag && (frag.sn === (lastFrag.sn+1));
+    const contiguous = !discontinuity && !trackSwitch && nextSN;
+    if (discontinuity) {
+      logger.log(`${this.id}:discontinuity detected`);
+    }
+    if (trackSwitch) {
+      logger.log(`${this.id}:switch detected`);
+    }
+    this.frag = frag;
     if (w) {
       // post fragment payload as transferable objects (no copy)
-      w.postMessage({cmd: 'demux', data, initSegment, audioCodec, videoCodec, timeOffset, cc, level, sn, duration, decryptdata, accurateTimeOffset,defaultInitPTS}, [data]);
+      w.postMessage({cmd: 'demux', data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset,defaultInitPTS}, [data]);
     } else {
       let demuxer = this.demuxer;
       if (demuxer) {
-        demuxer.push(data, initSegment, audioCodec, videoCodec, timeOffset, cc, level, sn, duration,decryptdata, accurateTimeOffset,defaultInitPTS);
+        demuxer.push(data, decryptdata, initSegment, audioCodec, videoCodec, timeOffset, discontinuity, trackSwitch, contiguous, duration, accurateTimeOffset,defaultInitPTS);
       }
     }
   }
@@ -83,6 +131,9 @@ class Demuxer {
         }
         /* falls through */
       default:
+        data.data = data.data || {};
+        data.data.frag = this.frag;
+        data.data.id = this.id;
         hls.trigger(data.event, data.data);
         break;
     }

--- a/src/demux/mp4demuxer.js
+++ b/src/demux/mp4demuxer.js
@@ -7,9 +7,8 @@ import Event from '../events';
 
  class MP4Demuxer {
 
-  constructor(observer, id, remuxer) {
+  constructor(observer, remuxer) {
     this.observer = observer;
-    this.id = id;
     this.remuxer = remuxer;
   }
 
@@ -17,7 +16,7 @@ import Event from '../events';
 
   }
 
-  resetInitSegment(initSegment,level,sn,audioCodec,videoCodec, duration) {
+  resetInitSegment(initSegment,audioCodec,videoCodec, duration) {
     //jshint unused:false
     const initData = this.initData = MP4Demuxer.parseInitSegment(initSegment);
     var tracks = {};
@@ -27,7 +26,7 @@ import Event from '../events';
     if (initData.video) {
       tracks.video = { container : 'video/mp4', codec : videoCodec, initSegment : initSegment};
     }
-    this.observer.trigger(Event.FRAG_PARSING_INIT_SEGMENT,{ id : this.id, level : level, sn : sn, unique : false, tracks : tracks });
+    this.observer.trigger(Event.FRAG_PARSING_INIT_SEGMENT,{ unique : false, tracks : tracks });
   }
 
   static probe(data) {
@@ -211,10 +210,10 @@ static startDTS(initData, fragment) {
 }
 
   // feed incoming data to the front of the parsing pipeline
-  append(data, timeOffset, cc, level, sn, contiguous,accurateTimeOffset) {
+  append(data, timeOffset,contiguous,accurateTimeOffset) {
     const initData = this.initData;
     const startDTS = MP4Demuxer.startDTS(initData,data);
-    this.remuxer.remux(level, sn , cc, initData.audio, initData.video, null, null, startDTS, contiguous,accurateTimeOffset,data);
+    this.remuxer.remux(initData.audio, initData.video, null, null, startDTS, contiguous,accurateTimeOffset,data);
   }
 
   destroy() {

--- a/src/demux/tsdemuxer.js
+++ b/src/demux/tsdemuxer.js
@@ -18,9 +18,8 @@
 
  class TSDemuxer {
 
-  constructor(observer, id, remuxer, config, typeSupported) {
+  constructor(observer, remuxer, config, typeSupported) {
     this.observer = observer;
-    this.id = id;
     this.config = config;
     this.typeSupported = typeSupported;
     this.remuxer = remuxer;
@@ -35,7 +34,7 @@
     }
   }
 
-  resetInitSegment(initSegment,level,sn,audioCodec,videoCodec, duration) {
+  resetInitSegment(initSegment,audioCodec,videoCodec, duration) {
     this.pmtParsed = false;
     this._pmtId = -1;
     this._avcTrack = {container : 'video/mp2t', type: 'video', id :-1, sequenceNumber: 0, samples : [], len : 0, dropped : 0};
@@ -55,7 +54,7 @@
   }
 
   // feed incoming data to the front of the parsing pipeline
-  append(data, timeOffset, cc, level, sn, contiguous,accurateTimeOffset) {
+  append(data, timeOffset, contiguous,accurateTimeOffset) {
     var start, len = data.length, stt, pid, atf, offset,pes,
         unknownPIDs = false;
     this.contiguous = contiguous;
@@ -183,7 +182,7 @@
             break;
         }
       } else {
-        this.observer.trigger(Event.ERROR, {type : ErrorTypes.MEDIA_ERROR, id : this.id, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: false, reason: 'TS packet did not start with 0x47'});
+        this.observer.trigger(Event.ERROR, {type : ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: false, reason: 'TS packet did not start with 0x47'});
       }
     }
     // try to parse last PES packets
@@ -217,7 +216,7 @@
       // either id3Data null or PES truncated, keep it for next frag parsing
       id3Track.pesData = id3Data;
     }
-    this.remuxer.remux(level, sn, cc, audioTrack, avcTrack, id3Track, this._txtTrack, timeOffset, contiguous, accurateTimeOffset);
+    this.remuxer.remux(audioTrack, avcTrack, id3Track, this._txtTrack, timeOffset, contiguous, accurateTimeOffset);
   }
 
   destroy() {
@@ -808,7 +807,7 @@
         fatal = true;
       }
       logger.warn(`parsing error:${reason}`);
-      this.observer.trigger(Event.ERROR, {type: ErrorTypes.MEDIA_ERROR, id : this.id, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: fatal, reason: reason});
+      this.observer.trigger(Event.ERROR, {type: ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: fatal, reason: reason});
       if (fatal) {
         return;
       }

--- a/src/errors.js
+++ b/src/errors.js
@@ -34,12 +34,12 @@ export const ErrorDetails = {
   FRAG_LOOP_LOADING_ERROR: 'fragLoopLoadingError',
   // Identifier for fragment load timeout error - data: { frag : fragment object}
   FRAG_LOAD_TIMEOUT: 'fragLoadTimeOut',
-  // Identifier for a fragment decryption error event - data: parsing error description
+  // Identifier for a fragment decryption error event - data: {id : demuxer Id,frag: fragment object, reason : parsing error description }
   FRAG_DECRYPT_ERROR: 'fragDecryptError',
   // Identifier for a fragment parsing error event - data: { id : demuxer Id, reason : parsing error description }
   // will be renamed DEMUX_PARSING_ERROR and switched to MUX_ERROR in the next major release
   FRAG_PARSING_ERROR: 'fragParsingError',
-  // Identifier for a remux alloc error event - data: { id : demuxer Id, bytes : nb of bytes on which allocation failed , reason : error text }
+  // Identifier for a remux alloc error event - data: { id : demuxer Id, frag : fragment object, bytes : nb of bytes on which allocation failed , reason : error text }
   REMUX_ALLOC_ERROR : 'remuxAllocError',
   // Identifier for decrypt key load error - data: { frag : fragment object, response : { code: error code, text: error text }}
   KEY_LOAD_ERROR: 'keyLoadError',

--- a/src/events.js
+++ b/src/events.js
@@ -61,7 +61,7 @@ module.exports = {
   SUBTITLE_TRACK_LOADED: 'hlsSubtitleTrackLoaded',
   // fired when a subtitle fragment has been processed - data: { success : boolean, frag : the processed frag}
   SUBTITLE_FRAG_PROCESSED: 'hlsSubtitleFragProcessed',
-  // fired when the first timestamp is found. - data: { id : demuxer id, initPTS: initPTS }
+  // fired when the first timestamp is found. - data: { id : demuxer id, initPTS: initPTS , frag : fragment object}
   INIT_PTS_FOUND: 'hlsInitPtsFound',
   // fired when a fragment loading starts - data: { frag : fragment object}
   FRAG_LOADING: 'hlsFragLoading',

--- a/src/events.js
+++ b/src/events.js
@@ -71,17 +71,17 @@ module.exports = {
   FRAG_LOAD_EMERGENCY_ABORTED: 'hlsFragLoadEmergencyAborted',
   // fired when a fragment loading is completed - data: { frag : fragment object, payload : fragment payload, stats : { trequest, tfirst, tload, length}}
   FRAG_LOADED: 'hlsFragLoaded',
-  // fired when a fragment has finished decrypting - data: { level : levelId, sn : sequence number }
+  // fired when a fragment has finished decrypting - data: { id : demuxer id, frag: fragment object, stats : {tstart,tdecrypt} }
   FRAG_DECRYPTED: 'hlsFragDecrypted',
-  // fired when Init Segment has been extracted from fragment - data: { id : demuxer id, level : levelId, sn : sequence number, moov : moov MP4 box, codecs : codecs found while parsing fragment}
+  // fired when Init Segment has been extracted from fragment - data: { id : demuxer id, frag: fragment object, moov : moov MP4 box, codecs : codecs found while parsing fragment}
   FRAG_PARSING_INIT_SEGMENT: 'hlsFragParsingInitSegment',
-  // fired when parsing sei text is completed - data: { id : demuxer id, , level : levelId, sn : sequence number, samples : [ sei samples pes ] }
+  // fired when parsing sei text is completed - data: { id : demuxer id, , frag: fragment object, samples : [ sei samples pes ] }
   FRAG_PARSING_USERDATA: 'hlsFragParsingUserdata',
-  // fired when parsing id3 is completed - data: { id : demuxer id, , level : levelId, sn : sequence number, samples : [ id3 samples pes ] }
+  // fired when parsing id3 is completed - data: { id : demuxer id, frag: fragment object, samples : [ id3 samples pes ] }
   FRAG_PARSING_METADATA: 'hlsFragParsingMetadata',
-  // fired when data have been extracted from fragment - data: { id : demuxer id, level : levelId, sn : sequence number, data1 : moof MP4 box or TS fragments, data2 : mdat MP4 box or null}
+  // fired when data have been extracted from fragment - data: { id : demuxer id, frag: fragment object, data1 : moof MP4 box or TS fragments, data2 : mdat MP4 box or null}
   FRAG_PARSING_DATA: 'hlsFragParsingData',
-  // fired when fragment parsing is completed - data: { id : demuxer id; level : levelId, sn : sequence number, }
+  // fired when fragment parsing is completed - data: { id : demuxer id,frag: fragment object }
   FRAG_PARSED: 'hlsFragParsed',
   // fired when fragment remuxed MP4 boxes have all been appended into SourceBuffer - data: { id : demuxer id,frag : fragment object, stats : { trequest, tfirst, tload, tparsed, tbuffered, length} }
   FRAG_BUFFERED: 'hlsFragBuffered',

--- a/src/remux/dummy-remuxer.js
+++ b/src/remux/dummy-remuxer.js
@@ -3,9 +3,8 @@
 */
 
 class DummyRemuxer {
-  constructor(observer, id) {
+  constructor(observer) {
     this.observer = observer;
-    this.id = id;
   }
 
   destroy() {

--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -10,9 +10,8 @@ import MP4 from '../remux/mp4-generator';
 import {ErrorTypes, ErrorDetails} from '../errors';
 
 class MP4Remuxer {
-  constructor(observer, id, config, typeSupported) {
+  constructor(observer, config, typeSupported) {
     this.observer = observer;
-    this.id = id;
     this.config = config;
     this.typeSupported = typeSupported;
     this.ISGenerated = false;
@@ -32,12 +31,10 @@ class MP4Remuxer {
     this.ISGenerated = false;
   }
 
-  remux(level,sn,cc,audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset) {
-    this.level = level;
-    this.sn = sn;
+  remux(audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset) {
     // generate Init Segment if needed
     if (!this.ISGenerated) {
-      this.generateIS(audioTrack,videoTrack,timeOffset,cc);
+      this.generateIS(audioTrack,videoTrack,timeOffset);
     }
 
     if (this.ISGenerated) {
@@ -74,10 +71,10 @@ class MP4Remuxer {
       this.remuxText(textTrack,timeOffset);
     }
     //notify end of parsing
-    this.observer.trigger(Event.FRAG_PARSED, { id : this.id , level : this.level, sn : this.sn});
+    this.observer.trigger(Event.FRAG_PARSED);
   }
 
-  generateIS(audioTrack,videoTrack,timeOffset,cc) {
+  generateIS(audioTrack,videoTrack,timeOffset) {
     var observer = this.observer,
         audioSamples = audioTrack.samples,
         videoSamples = videoTrack.samples,
@@ -85,7 +82,7 @@ class MP4Remuxer {
         typeSupported = this.typeSupported,
         container = 'audio/mp4',
         tracks = {},
-        data = { id : this.id, level : this.level, sn : this.sn, tracks : tracks, unique : false },
+        data = { tracks : tracks, unique : false },
         computePTSDTS = (this._initPTS === undefined),
         initPTS, initDTS;
 
@@ -144,7 +141,7 @@ class MP4Remuxer {
       if (computePTSDTS) {
         initPTS = Math.min(initPTS,videoSamples[0].pts - pesTimeScale * timeOffset);
         initDTS = Math.min(initDTS,videoSamples[0].dts - pesTimeScale * timeOffset);
-        this.observer.trigger(Event.INIT_PTS_FOUND, { id: this.id, initPTS: initPTS, cc: cc});
+        this.observer.trigger(Event.INIT_PTS_FOUND, { initPTS: initPTS});
       }
     }
 
@@ -156,7 +153,7 @@ class MP4Remuxer {
         this._initDTS = initDTS;
       }
     } else {
-      observer.trigger(Event.ERROR, {type : ErrorTypes.MEDIA_ERROR, id : this.id, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: false, reason: 'no audio/video samples found'});
+      observer.trigger(Event.ERROR, {type : ErrorTypes.MEDIA_ERROR, details: ErrorDetails.FRAG_PARSING_ERROR, fatal: false, reason: 'no audio/video samples found'});
     }
   }
 
@@ -291,7 +288,7 @@ class MP4Remuxer {
     try {
       mdat = new Uint8Array(mdatSize);
     } catch(err) {
-      this.observer.trigger(Event.ERROR, {type : ErrorTypes.MUX_ERROR, level: this.level, id : this.id, details: ErrorDetails.REMUX_ALLOC_ERROR, fatal: false, bytes : mdatSize, reason: `fail allocating video mdat ${mdatSize}`});
+      this.observer.trigger(Event.ERROR, {type : ErrorTypes.MUX_ERROR, details: ErrorDetails.REMUX_ALLOC_ERROR, fatal: false, bytes : mdatSize, reason: `fail allocating video mdat ${mdatSize}`});
       return;
     }
     let view = new DataView(mdat.buffer);
@@ -388,9 +385,6 @@ class MP4Remuxer {
     track.samples = [];
 
     let data = {
-      id : this.id,
-      level : this.level,
-      sn : this.sn,
       data1: moof,
       data2: mdat,
       startPTS: firstPTS / pesTimeScale,
@@ -567,7 +561,7 @@ class MP4Remuxer {
           try {
             mdat = new Uint8Array(mdatSize);
           } catch(err) {
-            this.observer.trigger(Event.ERROR, {type : ErrorTypes.MUX_ERROR, level: this.level, id : this.id, details: ErrorDetails.REMUX_ALLOC_ERROR, fatal: false, bytes : mdatSize, reason: `fail allocating audio mdat ${mdatSize}`});
+            this.observer.trigger(Event.ERROR, {type : ErrorTypes.MUX_ERROR, details: ErrorDetails.REMUX_ALLOC_ERROR, fatal: false, bytes : mdatSize, reason: `fail allocating audio mdat ${mdatSize}`});
             return;
           }
           if (!rawMPEG) {
@@ -642,9 +636,6 @@ class MP4Remuxer {
       }
       track.samples = [];
       let audioData = {
-        id : this.id,
-        level : this.level,
-        sn : this.sn,
         data1: moof,
         data2: mdat,
         startPTS: firstPTS / pesTimeScale,
@@ -709,9 +700,6 @@ class MP4Remuxer {
         sample.dts = ((sample.dts - this._initDTS) / this.PES_TIMESCALE);
       }
       this.observer.trigger(Event.FRAG_PARSING_METADATA, {
-        id : this.id,
-        level : this.level,
-        sn : this.sn,
         samples:track.samples
       });
     }
@@ -735,9 +723,6 @@ class MP4Remuxer {
         sample.pts = ((sample.pts - this._initPTS) / this.PES_TIMESCALE);
       }
       this.observer.trigger(Event.FRAG_PARSING_USERDATA, {
-        id : this.id,
-        level : this.level,
-        sn : this.sn,
         samples:track.samples
       });
     }

--- a/src/remux/passthrough-remuxer.js
+++ b/src/remux/passthrough-remuxer.js
@@ -4,9 +4,8 @@
 import Event from '../events';
 
 class PassThroughRemuxer {
-  constructor(observer,id) {
+  constructor(observer) {
     this.observer = observer;
-    this.id = id;
   }
 
   destroy() {
@@ -18,7 +17,7 @@ class PassThroughRemuxer {
   resetInitSegment() {
   }
 
-  remux(level,sn,cc,audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset,rawData) {
+  remux(audioTrack,videoTrack,id3Track,textTrack,timeOffset, contiguous,accurateTimeOffset,rawData) {
     var observer = this.observer;
     var streamType = '';
     if (audioTrack) {
@@ -28,9 +27,6 @@ class PassThroughRemuxer {
       streamType += 'video';
     }
     observer.trigger(Event.FRAG_PARSING_DATA, {
-      id : this.id,
-      level : level,
-      sn : sn,
       data1: rawData,
       startPTS: timeOffset,
       startDTS: timeOffset,
@@ -39,7 +35,7 @@ class PassThroughRemuxer {
       dropped : 0
     });
     //notify end of parsing
-    observer.trigger(Event.FRAG_PARSED, { id : this.id , level : level, sn : sn});
+    observer.trigger(Event.FRAG_PARSED);
   }
 }
 


### PR DESCRIPTION
### Description of the Changes

- [x] provide Fragment object to demuxer
- [x] use an internal EventEmitter() in demuxer to proxify demuxer/remuxer events
- [x] decorate events with demuxer id and frag
- [x] document changes

related to #709

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [x] new unit / functional tests have been added (whenever applicable)
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] API or design changes are documented in API.md
