### PR TITLE
IE11 - Closed caption rendering fix

### DIFF
--- a/src/utils/cues.js
+++ b/src/utils/cues.js
@@ -33,6 +33,13 @@ const Cues = {
         }
         //To be used for cleaning-up orphaned roll-up captions
         row.cueStartTime = startTime;
+
+        // Give a slight bump to the endTime if it's equal to startTime to avoid a SyntaxError in IE
+        if (startTime === endTime)
+        {
+          endTime += 0.0001;
+        }
+
         cue = new VTTCue(startTime, endTime, fixLineBreaks(text.trim()));
 
         if (indent >= 16)


### PR DESCRIPTION
### Description of the Changes
Small fix for issue #1023.

A SyntaxError was being thrown in IE when creating cues for closed captions that supplied a startTime and endTime of the same value. If they are the same, we now bump the endTime a slight amount.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] API or design changes are documented in API.md
