### PR TITLE
ensure sourceBuffer error is displayed in logs

### DIFF
--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -215,7 +215,7 @@ class BufferController extends EventHandler {
   }
 
   onSBUpdateError(event) {
-    logger.error(`sourceBuffer error:${event}`);
+    logger.error('sourceBuffer error:', event);
     // according to http://www.w3.org/TR/media-source/#sourcebuffer-append-error
     // this error might not always be fatal (it is fatal if decode error is set, in that case
     // it will be followed by a mediaElement error ...)


### PR DESCRIPTION
previously, in chrome, the following was displayed:

>[error] > sourceBuffer error:[object Event]